### PR TITLE
Mark `update` field as readonly

### DIFF
--- a/src/components/device-page/states.tsx
+++ b/src/components/device-page/states.tsx
@@ -37,6 +37,7 @@ const readonlyFields = [
     "contact",
     "action",
     "click",
+    "update",
     "update_available"
 ];
 

--- a/src/components/device-page/states.tsx
+++ b/src/components/device-page/states.tsx
@@ -38,7 +38,8 @@ const readonlyFields = [
     "action",
     "click",
     "update",
-    "update_available"
+    "update_available",
+    "power"
 ];
 
 class States extends Component<StatesProps & PropsFromStore & StateApi, {}> {


### PR DESCRIPTION
When `new_api: true` in zigbee2mqtt is set, the more detailed `update` field is used.

This field, like `update_available` is also readonly.