### PR TITLE
Fix battery not working when 0%

### DIFF
--- a/src/components/power-source/index.tsx
+++ b/src/components/power-source/index.tsx
@@ -10,11 +10,11 @@ interface PowerSourceProps {
 
 
 const PowerSource: FunctionComponent<PowerSourceProps> = ({ source, battery, ...rest }) => {
-    let batteryClass = "fa-battery-full";
+    let batteryClass = "fa-battery-slash";
 
     switch (source) {
         case "Battery":
-            if (battery) {
+            if (battery || (battery === 0)) {
                 if (battery > 75) {
                     batteryClass = "fa-battery-full";
                 } else if (battery >= 75) {


### PR DESCRIPTION
- replaces the default with the battery with slash icon (seems a better default for unknown state)
- update if to also work when battery is 0%