### PR TITLE
feat(html): make favicon relative

### DIFF
--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Zigbee2MQTT</title>
-    <link rel='shortcut icon' type='image/x-icon' href='/favicon.ico' />
+    <link rel='shortcut icon' type='image/x-icon' href='favicon.ico' />
 
 </head>
 


### PR DESCRIPTION
Previously, the URL was absolute to the root of the domain `/favicon.ico` which required the favicon be served there. This makes the favicon relative to the current file, allowing the icon to load when the frontend is served from a sub-directory / different path.