### PR TITLE
use property for binary feature onChange

### DIFF
--- a/src/components/features/binary/binary.tsx
+++ b/src/components/features/binary/binary.tsx
@@ -11,7 +11,7 @@ const Binary: FunctionComponent<BinaryProps> = (props) => {
   const { feature: { access, endpoint, name, property, value_off: valueOff, value_on: valueOn }, deviceState, onChange } = props;
   if (access & FeatureAccessMode.ACCESS_WRITE) {
     return <Toggle
-      onChange={(value) => onChange(endpoint, { [name]: value })}
+      onChange={(value) => onChange(endpoint, { [property]: value })}
       value={deviceState[property]}
       valueOn={valueOn}
       valueOff={valueOff}


### PR DESCRIPTION
In zigbee-herdsman-converters Binary exposes are all created with `name="state"`.
See http://github.com/Koenkk/zigbee-herdsman-converters/blob/3afe90a3014a8fbe94e2a3596169041092ee3e2b/lib/exposes.js#L45-L45
and http://github.com/Koenkk/zigbee-herdsman-converters/blob/3afe90a3014a8fbe94e2a3596169041092ee3e2b/lib/exposes.js#L73-L73

So generally `property` should be used to set new device state instead of `name`.

See https://github.com/Koenkk/zigbee2mqtt/issues/5233 for reference.

