### PR TITLE
Front-end layout improvements

### DIFF
--- a/src/components/logs-page/index.tsx
+++ b/src/components/logs-page/index.tsx
@@ -59,12 +59,12 @@ export class LogsPage extends Component<GlobalState, LogsPageState> {
             {this.renderSearch()}
             {
                 logs.map((l, idx) => <div key={idx}>
-                    <span className={cx({
-                        'text-danger': l.level === 'error',
-                        'text-warning': l.level === 'warning',
-                        'text-info': l.level === 'info',
-                        'd-none': logLevel !== ALL
-                    })}>{l.level.toUpperCase()}:&nbsp;</span><code>
+                    {logLevel === ALL && <><span className={cx("badge", {
+                        'bg-danger': l.level === 'error',
+                        'bg-warning': l.level === 'warning',
+                        'bg-info': l.level === 'info',
+                        'bg-secondary': ['error', 'warning', 'info'].includes(l.level) === false,
+                    }, "text-capitalize")}>{l.level}</span>&nbsp;</>}<code>
                         <Highlighted text={l.message} highlight={search}></Highlighted>
                     </code></div>)
             }</div>

--- a/src/components/settings/index.tsx
+++ b/src/components/settings/index.tsx
@@ -132,7 +132,7 @@ export class SettingsPage extends Component<SettingsPageProps & BridgeApi & Glob
             {
                 !isEmpty(bridgeInfo) && settings.map(setting => (
                     <div key={setting.key} className="row">
-                        <div className="col">
+                        <div className="col mb-3">
                             <label htmlFor={setting.key}>{setting.title}</label>
                             <UniversalEditor
                                 disabled={get(bridgeInfo, setting.path) === undefined}

--- a/src/components/settings/index.tsx
+++ b/src/components/settings/index.tsx
@@ -131,9 +131,9 @@ export class SettingsPage extends Component<SettingsPageProps & BridgeApi & Glob
         return <><div className="mt-2">
             {
                 !isEmpty(bridgeInfo) && settings.map(setting => (
-                    <div key={setting.key} className="row">
+                    <div key={setting.key} className="row border-bottom pt-1">
                         <div className="col mb-3">
-                            <label htmlFor={setting.key}>{setting.title}</label>
+                            <label htmlFor={setting.key} className="form-label">{setting.title}</label>
                             <UniversalEditor
                                 disabled={get(bridgeInfo, setting.path) === undefined}
                                 value={get(bridgeInfo, setting.path) as string | ReadonlyArray<string> | number}

--- a/ws-messages/onConnect.json
+++ b/ws-messages/onConnect.json
@@ -64,3 +64,7 @@
 {"payload":{"battery":100,"contact":false,"last_seen":"2021-01-08T06:12:46+08:00","voltage":3015},"topic":"Bedroom room ac power"}
 {"payload":{"battery":34,"last_seen":"2021-01-07T20:19:35+08:00","update":{"state":"idle"},"update_available":false},"topic":"0xbc33acfffe17628b"}
 {"payload":{"co2":403,"humidity":59.34,"last_seen":"2021-01-08T07:02:07+08:00","linkquality":115,"pressure":1005,"temperature":31.77},"topic":"Airsense/FD11"}
+{"payload":{"level":"info","message":"MQTT publish: topic 'zigbee2mqtt/Master Bedroom Dimmer', payload '{\"brightness\":254,\"current\":0.18,\"energy\":48.82,\"linkquality\":48,\"power\":25.5,\"state\":\"OFF\",\"voltage\":171.9}'"},"topic":"bridge/logging"}
+{"payload":{"level":"warning","message":"MQTT publish: topic 'zigbee2mqtt/Master Bedroom Dimmer', payload '{\"brightness\":254,\"current\":0.18,\"energy\":48.82,\"linkquality\":48,\"power\":25.5,\"state\":\"OFF\",\"voltage\":171.9}'"},"topic":"bridge/logging"}
+{"payload":{"level":"error","message":"MQTT publish: topic 'zigbee2mqtt/Master Bedroom Dimmer', payload '{\"brightness\":254,\"current\":0.18,\"energy\":48.82,\"linkquality\":48,\"power\":25.5,\"state\":\"OFF\",\"voltage\":171.9}'"},"topic":"bridge/logging"}
+{"payload":{"level":"something","message":"some message"},"topic":"bridge/logging"}


### PR DESCRIPTION
This PR has 2 minor changes:

## Introduce badges on the logs for easier visibility

![image](https://user-images.githubusercontent.com/85504/104447459-bdee5a00-5593-11eb-95b2-abfdb6b9cacd.png)

## Add some margin between the form items in settings (follows bootstrap 5 recommended margin specs)

Before:
![image](https://user-images.githubusercontent.com/85504/104447572-e0807300-5593-11eb-805d-b136e45cfa67.png)

After:
![image](https://user-images.githubusercontent.com/85504/104447593-e9714480-5593-11eb-8c62-de03b1c96b16.png)
