### PR TITLE
Remove hardcoded presets for color_temp

### DIFF
--- a/src/components/features/light/light.tsx
+++ b/src/components/features/light/light.tsx
@@ -7,8 +7,7 @@ import Composite from "../composite/composite";
 
 type LightProps = BaseFeatureProps<LightFeature>
 const stepsConfiguration = {
-  brightness: [0, 25, 50, 75, 100].map<ValueWithLabelOrPrimitive>(item => ({ value: scale(item, [0, 100], [0, 255]), name: item + '%' })),
-  'color_temp': [1000, 2000, 3000, 4000, 5000, 6500].map<ValueWithLabelOrPrimitive>(kelvin => ({ value: 1000000.0 / kelvin, name: kelvin + 'K' }))
+  brightness: [0, 25, 50, 75, 100].map<ValueWithLabelOrPrimitive>(item => ({ value: scale(item, [0, 100], [0, 255]), name: item + '%' }))
 };
 
 const Light: FunctionComponent<LightProps> = (props) => <Composite type="light" {...props} stepsConfiguration={stepsConfiguration} />;


### PR DESCRIPTION
These are no longer needed once https://github.com/Koenkk/zigbee-herdsman-converters/pull/2113 gets merged.