### PR TITLE
Dashboard: Move device icon to header. Fixes  #364

### DIFF
--- a/src/components/dashboard-page/DashboardDevice.tsx
+++ b/src/components/dashboard-page/DashboardDevice.tsx
@@ -20,11 +20,10 @@ const DashboardDevice: React.FC<Props> = ({ onChange, onRead, device, deviceStat
         <div className="col-xl-3 col-lg-4 col-sm-6 col-12 d-flex">
             <div className={`flex-fill card flex-shrink-1`}>
                 <div className="card-header text-truncate pb-0">
-                    <Link to={genDeviceDetailsLink(device.ieee_address)}>{device.friendly_name}</Link>
+                    <Link to={genDeviceDetailsLink(device.ieee_address)}><DeviceImage device={device} className={cx(styles.deviceImage, 'me-1')} /> {device.friendly_name}</Link>
                 </div>
                 <div className={`align-items-center card-body row`}>
-                    <DeviceImage device={device} className={cx(styles.deviceImage, 'col col-1')} />
-                    <div className="col col-11">
+                    <div className="col">
                         <Composite feature={{ features } as CompositeFeature}
                             type="composite"
                             device={device}


### PR DESCRIPTION
Device icon has moved to card header 