### PR TITLE
fix(style): double scrollbars due to bootstrap

### DIFF
--- a/src/styles/styles.global.scss
+++ b/src/styles/styles.global.scss
@@ -4,10 +4,14 @@
     }
 }
 
+body {
+    overflow-y: auto !important;
+}
+
 .animation-blinking {
     animation: blinker 1s linear infinite;
 }
 
 .content {
-    overflow-y: scroll;
+    overflow-y: auto;
 }


### PR DESCRIPTION
Removes the double scrollbar created by `bootstrap`'s default styles.

Bootstrap adds `overflow-y: scroll;` to the body, expecting that the body will be the main scroll component, but the current navbar is sticky at the top, which sort of defeats the reason for  the scroll in the first place.

With this MR we fix it so only the necessary scrollbar is shown. 

This was tested in FF, Chrome, Safari and Android mobile.

|Before | After|
| --- | --- |
| <img width="213" alt="Screen Shot 2021-05-02 at 14 52 55" src="https://user-images.githubusercontent.com/9891233/116813824-1dc63c00-ab56-11eb-8c5b-9c6de1cd38b3.png"> | <img width="213" alt="Screen Shot 2021-05-02 at 14 52 35" src="https://user-images.githubusercontent.com/9891233/116813825-1ef76900-ab56-11eb-96d3-a5b264ff5c7f.png"> |
