### PR TITLE
Update es.json

### DIFF
--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -10,6 +10,7 @@
         "close": "Cerrar",
         "cluster": "Cluster",
         "clusters": "Clusters",
+        "the_only_endpoint": "El único endpoint",
         "confirmation": "Mensaje de confirmación",
         "delete": "Borrar",
         "destination": "Destino",
@@ -259,6 +260,7 @@
         "false": "Falso",
         "leaking": "Fuga",
         "not_supported": "No soportado",
+        "null": "Nulo",
         "occupied": "Ocupado",
         "open": "Abierto",
         "supported": "Soportado",
@@ -298,6 +300,7 @@
         "support_status": "Soportado",
         "unsupported": "No soportado",
         "update_Home_assistant_entity_id": "Actualizar el ID de entidad de Home Assistant",
+        "zigbee_manufacturer": "Fabricante Zigbee",
         "zigbee_model": "Modelo Zigbee "
     }
 }


### PR DESCRIPTION
More Spanish translations.

The web ui shows me a lot of descriptions to translate, but they are strange, they have spaces into the key. They are right? We need to translate them?

```json
    "featureDescriptions": {
        "Indicates whether the device detected smoke": "Indicates whether the device detected smoke",
        "Indicates if the battery of this device is almost empty": "Indicates if the battery of this device is almost empty",
        "Indicates whether the device is tampered": "Indicates whether the device is tampered",
        "Remaining battery in %": "Remaining battery in %",
        "Voltage of the battery in millivolts": "Voltage of the battery in millivolts",
        "Link quality (signal strength)": "Link quality (signal strength)",
        "On/off state of the switch": "On/off state of the switch",
        "Instantaneous measured power": "Instantaneous measured power",
        "Instantaneous measured electrical current": "Instantaneous measured electrical current",
        "Measured electrical potential value": "Measured electrical potential value",
        "Sum of consumed energy": "Sum of consumed energy",
        "Recover state after power outage": "Recover state after power outage",
        "Indicates whether the device detected a water leak": "Indicates whether the device detected a water leak",
        "Raw measured illuminance": "Raw measured illuminance",
        "Measured illuminance in lux": "Measured illuminance in lux",
        "Indicates whether the device detected occupancy": "Indicates whether the device detected occupancy",
        "Measured temperature value": "Measured temperature value",
        "Indicates if the contact is closed (= true) or open (= false)": "Indicates if the contact is closed (= true) or open (= false)",
        "Triggered action (e": {
            "g": {
                " a button click)": "Triggered action (e.g. a button click)"
            }
        },
        "Enabling prevents both relais being on at the same time": "Enabling prevents both relais being on at the same time",
        "Measured relative humidity": "Measured relative humidity",
        "The measured atmospheric pressure": "The measured atmospheric pressure"
    },
```