### PR TITLE
Updated NL translations

### DIFF
--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -260,12 +260,12 @@
     "values": {
         "clear": "Geen",
         "closed": "Gesloten",
-        "false": "Onjuist",
+        "false": "Onwaar",
         "not_supported": "Niet ondersteund",
         "occupied": "Beweging",
         "open": "Open",
         "supported": "Ondersteund",
-        "true": "Juist",
+        "true": "Waar",
         "empty_string": "Lege waarde(\"\")",
         "leaking": "Lekkage",
         "tampered": "Gesaboteerd"


### PR DESCRIPTION
The translations 'juist' (true) and 'onjuist' (false) sound more like 'correct' and 'incorrect' in English. The translation 'waar' and 'onwaar' seems more correct in this context.