### PR TITLE
Change vendor url to new format

### DIFF
--- a/src/components/vendor-links/verndor-links.tsx
+++ b/src/components/vendor-links/verndor-links.tsx
@@ -16,7 +16,7 @@ export const VendorLink: React.FunctionComponent<VendorProps> = (props: VendorPr
     const { t } = useTranslation("zigbee");
     const { device } = props;
     if (device.supported && device.definition) {
-        const url = `https://www.zigbee2mqtt.io/information/supported_devices.html#${encodeURIComponent(normalizeModel(device.definition.vendor?.toLowerCase()))}`;
+        const url = `https://www.zigbee2mqtt.io/information/supported_devices.html#v=${encodeURIComponent(normalizeModel(device.definition.vendor?))}`;
         return <a target="_blank" rel="noopener noreferrer" href={url}>{device.definition.vendor}</a>
     }
     return <Fragment>{t('unsupported')}</Fragment>;

--- a/src/components/vendor-links/verndor-links.tsx
+++ b/src/components/vendor-links/verndor-links.tsx
@@ -16,7 +16,7 @@ export const VendorLink: React.FunctionComponent<VendorProps> = (props: VendorPr
     const { t } = useTranslation("zigbee");
     const { device } = props;
     if (device.supported && device.definition) {
-        const url = `https://www.zigbee2mqtt.io/information/supported_devices.html#v=${encodeURIComponent(normalizeModel(device.definition.vendor?))}`;
+        const url = `https://www.zigbee2mqtt.io/information/supported_devices.html#v=${encodeURIComponent(normalizeModel(device.definition.vendor))}`;
         return <a target="_blank" rel="noopener noreferrer" href={url}>{device.definition.vendor}</a>
     }
     return <Fragment>{t('unsupported')}</Fragment>;


### PR DESCRIPTION
The device page was updated recently (in https://github.com/Koenkk/zigbee2mqtt.io/pull/942 I think).
The new link applies the device filter according to the new url format.

Old: https://www.zigbee2mqtt.io/information/supported_devices.html#ikea
New: https://www.zigbee2mqtt.io/information/supported_devices.html#v=IKEA