### PR TITLE
Small typo: tranlations -> translations

### DIFF
--- a/src/components/settings/index.tsx
+++ b/src/components/settings/index.tsx
@@ -148,7 +148,7 @@ export class SettingsPage extends Component<PropsFromStore & SettingsPageProps &
         const url = `https://github.com/nurikk/zigbee2mqtt-frontend/edit/dev/src/i18n/locales/${currentLanguage}.json`;
         return <div className="p-3">
             <p>This page contains missing translation keys.</p>
-            <p>You can navigate to different pages to collect missing tranlations and come back here again (don't referesh browser page).</p>
+            <p>You can navigate to different pages to collect missing translations and come back here again (don't referesh browser page).</p>
             <p>Usually there is a lot of missing keys in settings and device pages</p>
             <p>Then you can navigate to <a target="_blank" rel="noopener noreferrer" href={url}>Github</a> and raise a PR with translated missing keys</p>
             <pre>{JSON.stringify(missingTranslations, null, 4)}</pre>


### PR DESCRIPTION
Fix for a small typo.