### PR TITLE
Add link to OTA changelog

### DIFF
--- a/src/components/ota-page/index.tsx
+++ b/src/components/ota-page/index.tsx
@@ -9,7 +9,7 @@ import Button from "../button";
 import { genDeviceDetailsLink, toHHMMSS } from "../../utils";
 import { Link } from "react-router-dom";
 import { Device, DeviceState } from "../../types";
-import { VendorLink, ModelLink } from "../vendor-links/verndor-links";
+import { VendorLink, ModelLink, OTALink } from "../vendor-links/verndor-links";
 import { useTranslation, WithTranslation, withTranslation } from "react-i18next";
 
 
@@ -46,7 +46,7 @@ const OtaRow: FunctionComponent<OtaRowProps & OtaApi> = (props) => {
         <td className="text-truncate text-nowrap position-relative"><VendorLink device={device} /></td>
         <td title={device?.definition?.description}><ModelLink device={device} /></td>
         <td>{device.date_code}</td>
-        <td>{device.software_build_id}</td>
+        <td><OTALink device={device} /></td>
         <td>
             <StateCell device={device} state={state} {...rest} />
         </td>

--- a/src/components/vendor-links/verndor-links.tsx
+++ b/src/components/vendor-links/verndor-links.tsx
@@ -37,3 +37,26 @@ export const ModelLink: React.FunctionComponent<VendorProps> = (props: VendorPro
     }
     return <a target="_blank" rel="noopener noreferrer" href={url}>{title}</a>
 }
+
+
+export const OTALink: React.FunctionComponent<VendorProps> = (props: VendorProps) => {
+    const { device, anchor } = props;
+    let url = '';
+    let title = device.software_build_id;
+
+    switch (device?.definition?.vendor) {
+        case "IKEA":
+            url = `https://ww8.ikea.com/ikeahomesmart/releasenotes/releasenotes.html`
+            break
+
+        case "Ubisys":
+            url = `https://www.ubisys.de/en/support/firmware/changelog-${device.definition?.model?.replace(/[-]/g, '').toLowerCase()}/`
+            break
+    }
+
+    if (url != '') {
+        return <a target="_blank" rel="noopener noreferrer" href={url}>{title}</a>
+    } else {
+        return <>{title}</>
+    }
+}


### PR DESCRIPTION
Only add link if vendor has a changelog. I could only find a changelog-page for IKEA and Ubisys. LEDVANCE does have a [firmware overview](https://update.ledvance.com/firmware-overview) page, but these changelogs are downloadable text-files.