### PR TITLE
Fix Composites behavior (rendering and publishing)

### DIFF
--- a/src/components/features/composite/composite.tsx
+++ b/src/components/features/composite/composite.tsx
@@ -42,8 +42,13 @@ export class Composite extends Component<CompositeProps & WithTranslation<"compo
         }
     }
     onCompositeFeatureApply = (): void=> {
-        const { onChange, feature: { endpoint, property } } = this.props;
-        onChange(endpoint as Endpoint, property ? { [property]: this.state } : this.state);
+        const { onChange, deviceState, feature: { endpoint, property, features } } = this.props;
+
+        const properties = features.map(f => f.property);
+        const compositePropertiesState = properties.reduce((acc, p) => ({ ...acc, [p]: deviceState[p]}), {});
+        const compositeState = {...compositePropertiesState, ...this.state};
+
+        onChange(endpoint as Endpoint, property ? { [property]: compositeState } : compositeState);
     }
 
     onRead = (endpoint: Endpoint, property: Record<string, unknown>): void=> {
@@ -64,6 +69,9 @@ export class Composite extends Component<CompositeProps & WithTranslation<"compo
         const isMoreThanOneFeature = features.length > 1;
         const doGroupingByEndpoint = !minimal;
         let result = [] as JSX.Element[];
+
+        const compositeDeviceState = {...deviceState, ...this.state};
+
         if (doGroupingByEndpoint) {
             const groupedFeatures = groupBy(features, f => f.endpoint ?? MAGIC_NO_ENDPOINT);
 
@@ -72,7 +80,7 @@ export class Composite extends Component<CompositeProps & WithTranslation<"compo
                     key={JSON.stringify(f)}
                     feature={f}
                     device={device}
-                    deviceState={deviceState}
+                    deviceState={compositeDeviceState}
                     onChange={this.onChange}
                     onRead={this.onRead}
                     featureWrapperClass={featureWrapperClass}
@@ -86,7 +94,7 @@ export class Composite extends Component<CompositeProps & WithTranslation<"compo
                     key={f.name + f.endpoint}
                     feature={f}
                     device={device}
-                    deviceState={deviceState}
+                    deviceState={compositeDeviceState}
                     onChange={this.onChange}
                     onRead={this.onRead}
                     featureWrapperClass={featureWrapperClass}
@@ -98,7 +106,7 @@ export class Composite extends Component<CompositeProps & WithTranslation<"compo
                 key={JSON.stringify(f)}
                 feature={f}
                 device={device}
-                deviceState={deviceState}
+                deviceState={compositeDeviceState}
                 onChange={this.onChange}
                 onRead={this.onRead}
                 featureWrapperClass={featureWrapperClass}


### PR DESCRIPTION
From my understanding a Composite acts as a container for multiple Features (e.g. a time schedule ), which can be applied at once (e.g. a button click).

Issue 1: Modifications are not rendered (see e.g. issue #927).
Currently the modified state is stored (in this.state)  but not rendered. This leads to confusion and is not consistent with other Features where the modification is rendered immediately. For consistency the modification should be rendered immediately. This however leads to the question what should be rendered if there is a modification and the state of the device changes. I would still suggest that the modification is rendered.

Issue 2: Only modified features are published.
I think it would be beneficial to publish the entire Composite state (as a combination of modifications and device state). Not sure if this is correct and consistent accross the project.