### PR TITLE
fix(ReactTableCom): update Bootstrap spacer class

### DIFF
--- a/src/components/grid/ReactTableCom.tsx
+++ b/src/components/grid/ReactTableCom.tsx
@@ -103,7 +103,7 @@ export const Table: React.FC<Props> = ({ columns, data, id }) => {
           <tr {...headerGroup.getHeaderGroupProps()}>
             {headerGroup.headers.map(column => (
               <th className="text-nowrap" {...column.getHeaderProps(column.getSortByToggleProps())}>
-                <span className={cx({ 'btn-link mr-1': column.canSort })}>{column.render('Header')}</span>
+                <span className={cx({ 'btn-link me-1': column.canSort })}>{column.render('Header')}</span>
                 <span>
                   <i className={cx('fa', {
                     'fa-sort-amount-down invisible': !column.isSorted,


### PR DESCRIPTION
This update the `mr-1` class to be `me-1` to apply spacing at the end (https://getbootstrap.com/docs/5.0/utilities/spacing/)