### PR TITLE
Display device images on OTA page

### DIFF
--- a/src/components/ota-page/index.tsx
+++ b/src/components/ota-page/index.tsx
@@ -1,11 +1,11 @@
-
 import React, { Component, FunctionComponent } from "react";
-
+import style from "./style.css";
 import { connect } from "unistore/react";
 import actions from "../../actions/actions";
 import { OtaApi } from "../../actions/OtaApi";
 import { GlobalState } from "../../store";
 import Button from "../button";
+import DeviceImage from "../device-image";
 import { genDeviceDetailsLink, toHHMMSS } from "../../utils";
 import { Link } from "react-router-dom";
 import { Device, DeviceState, OTAState } from "../../types";
@@ -70,6 +70,11 @@ class OtaPage extends Component<PropsFromStore & OtaApi & WithTranslation<"ota">
         const otaApi = { checkOTA, updateOTA };
         const otaDevices = this.getAllOtaDevices();
         const columns: Column<OtaGridData>[] = [
+            {
+                Header: t('zigbee:pic') as string,
+                Cell: ({ row: { original: { device, state } } }) => <DeviceImage className={style["device-image"]} device={device} deviceStatus={state} />,
+                disableSortBy: true,
+            },
             {
                 Header: t('zigbee:friendly_name') as string,
                 accessor: ({ device }) => device.friendly_name,

--- a/src/components/ota-page/style.css
+++ b/src/components/ota-page/style.css
@@ -1,0 +1,3 @@
+.device-image img {
+    max-height: 2em;
+}

--- a/src/components/ota-page/style.css.d.ts
+++ b/src/components/ota-page/style.css.d.ts
@@ -1,0 +1,12 @@
+declare namespace StyleCssNamespace {
+    export interface IStyleCss {
+        'device-image': string;
+    }
+}
+
+declare const StyleCssModule: StyleCssNamespace.IStyleCss & {
+    /** WARNING: Only available when `css-loader` is used without `style-loader` or `mini-css-extract-plugin` */
+    locals: StyleCssNamespace.IStyleCss;
+};
+
+export = StyleCssModule;


### PR DESCRIPTION
This adds a column for the device image into the table on the OTA page, like on in the main Devices table, for ease of browsing and visually identifying different devices.

Having the image shown is particularly useful when using a custom picture (e.g. of the real device itself) but also as model numbers + firmware versions can be very similar (or identical).  Seeing different images helps with quickly identifying the device in the listing. 