### PR TITLE
Added text to "save description" button in English

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1732,7 +1732,7 @@
         "execute": "Execute",
         "command": "Command",
         "payload": "Payload",
-        "save_description": ""
+        "save_description": "Save description"
     },
     "scene": {
         "scene_id": "Scene ID",


### PR DESCRIPTION
This looks a bit confusing (for some reason the colors in the screenshot are weird, please ignore that)

![image](https://user-images.githubusercontent.com/270571/183265480-df3be13c-4b3b-4f39-8bb1-79a00b993515.png)
