### PR TITLE
Use 'image' translation key for disk image context

### DIFF
--- a/src/components/ota-page/index.tsx
+++ b/src/components/ota-page/index.tsx
@@ -71,7 +71,7 @@ class OtaPage extends Component<PropsFromStore & OtaApi & WithTranslation<"ota">
         const otaDevices = this.getAllOtaDevices();
         const columns: Column<OtaGridData>[] = [
             {
-                Header: t('zigbee:pic') as string,
+                Header: t('zigbee:image') as string,
                 Cell: ({ row: { original: { device, state } } }) => <DeviceImage className={style["device-image"]} device={device} deviceStatus={state} />,
                 disableSortBy: true,
             },

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1987,6 +1987,7 @@
         "force_remove": "Force remove",
         "friendly_name": "Friendly name",
         "ieee_address": "IEEE Address",
+        "image": "Image",
         "input_clusters": "Input clusters",
         "interview_completed": "Interview completed",
         "interview_failed": "Interview failed",


### PR DESCRIPTION
I noticed in the Dutch translation, the word 'Afbeelding' is used on the OTA firmware page, which looks strange because 'Afbeelding' translates into 'Image' as in 'Picture':
![image](https://user-images.githubusercontent.com/695622/207150355-7acc4699-55cb-4875-8324-973b62bebc25.png)

And when I checked the English language, it said `Pic`
![image](https://user-images.githubusercontent.com/695622/207151333-4f910d68-e747-4206-8e8b-0d1fdcbf6295.png)

This is because we only have 1 key for `Pic`, which is used in two contexts:
- A picture, for example the device list
- A firmware image, in the OTA page

So this PR will add a 'Image' key that is used for the English 'image' in the context of 'Disk Image'. For the word 'image' in the context of picture, we can still use `pic` key.

I noticed POedit is being used for managing translations. I did make changes to the en.json file, not sure if that is how it should work? 

### Result

OTA page: 
![image](https://user-images.githubusercontent.com/695622/207155015-86eb59b4-47c7-4686-9601-fa04dc455479.png)


Devices page:
![image](https://user-images.githubusercontent.com/695622/207155146-7d48f906-1adb-4a4c-8bb9-f69386cb7ba1.png)
