### PR TITLE
Improve composite exposes

### DIFF
--- a/src/components/device-page/type-guards.ts
+++ b/src/components/device-page/type-guards.ts
@@ -1,6 +1,10 @@
 
 import { GenericExposedFeature, BinaryFeature, NumericFeature, EnumFeature, LightFeature, CompositeFeature, SwitchFeature, CoverFeature, LockFeature, ColorFeature, TextualFeature, ClimateFeature, FanFeature, ListFeature, GradientFeature } from "../../types";
 
+export function isGenericExposedFeature(feature: GenericExposedFeature | CompositeFeature): feature is GenericExposedFeature {
+  return !feature.hasOwnProperty('features');
+}
+
 export function isBinaryFeature(feature: GenericExposedFeature | CompositeFeature): feature is BinaryFeature {
   return feature.type === "binary";
 }

--- a/src/components/features/composite/Feature.tsx
+++ b/src/components/features/composite/Feature.tsx
@@ -22,9 +22,9 @@ import Gradient from "../gradient/gradient";
 
 interface FeatureProps extends Omit<React.HTMLAttributes<HTMLDivElement>, "onChange"> {
     feature: CompositeFeature | GenericExposedFeature;
+    parentFeatures: (CompositeFeature | GenericExposedFeature)[];
     deviceState: DeviceState;
     device: Device;
-    depth: number;
     stepsConfiguration?: Record<string, unknown>;
     onChange(endpoint: Endpoint, value: Record<string, unknown>): void;
     onRead(endpoint: Endpoint, value: Record<string, unknown>): void;
@@ -34,9 +34,9 @@ interface FeatureProps extends Omit<React.HTMLAttributes<HTMLDivElement>, "onCha
 
 export const Feature = (props: FeatureProps): JSX.Element => {
 
-    const { feature, device, deviceState, stepsConfiguration, onRead, onChange, featureWrapperClass: FeatureWrapper, minimal, depth } = props;
+    const { feature, device, deviceState, stepsConfiguration, onRead, onChange, featureWrapperClass: FeatureWrapper, minimal, parentFeatures } = props;
 
-    const genericParams = { key: JSON.stringify(feature), device, deviceState, onChange, onRead, featureWrapperClass: FeatureWrapper, minimal };
+    const genericParams = { key: JSON.stringify(feature), device, deviceState, onChange, onRead, featureWrapperClass: FeatureWrapper, minimal, parentFeatures };
     const wrapperParams = { key: JSON.stringify(feature), feature, onRead, deviceState };
 
     if (isBinaryFeature(feature)) {
@@ -83,7 +83,7 @@ export const Feature = (props: FeatureProps): JSX.Element => {
         return <Fan feature={feature} {...genericParams} />
     } else if (isCompositeFeature(feature)) {
         return <FeatureWrapper {...wrapperParams}>
-            <Composite type="composite" feature={feature} {...genericParams} depth={depth} deviceState={(deviceState[feature.property] ?? {}) as DeviceState} />
+            <Composite type="composite" feature={feature} {...genericParams} deviceState={(deviceState[feature.property] ?? {}) as DeviceState} />
         </FeatureWrapper>
     }
     return (<FeatureWrapper {...wrapperParams}>

--- a/src/components/features/composite/Feature.tsx
+++ b/src/components/features/composite/Feature.tsx
@@ -24,6 +24,7 @@ interface FeatureProps extends Omit<React.HTMLAttributes<HTMLDivElement>, "onCha
     feature: CompositeFeature | GenericExposedFeature;
     deviceState: DeviceState;
     device: Device;
+    depth: number;
     stepsConfiguration?: Record<string, unknown>;
     onChange(endpoint: Endpoint, value: Record<string, unknown>): void;
     onRead(endpoint: Endpoint, value: Record<string, unknown>): void;
@@ -33,7 +34,7 @@ interface FeatureProps extends Omit<React.HTMLAttributes<HTMLDivElement>, "onCha
 
 export const Feature = (props: FeatureProps): JSX.Element => {
 
-    const { feature, device, deviceState, stepsConfiguration, onRead, onChange, featureWrapperClass: FeatureWrapper, minimal } = props;
+    const { feature, device, deviceState, stepsConfiguration, onRead, onChange, featureWrapperClass: FeatureWrapper, minimal, depth } = props;
 
     const genericParams = { key: JSON.stringify(feature), device, deviceState, onChange, onRead, featureWrapperClass: FeatureWrapper, minimal };
     const wrapperParams = { key: JSON.stringify(feature), feature, onRead, deviceState };
@@ -82,7 +83,7 @@ export const Feature = (props: FeatureProps): JSX.Element => {
         return <Fan feature={feature} {...genericParams} />
     } else if (isCompositeFeature(feature)) {
         return <FeatureWrapper {...wrapperParams}>
-            <Composite type="composite" feature={feature} {...genericParams} deviceState={(deviceState[feature.property] ?? {}) as DeviceState} />
+            <Composite type="composite" feature={feature} {...genericParams} depth={depth} deviceState={(deviceState[feature.property] ?? {}) as DeviceState} />
         </FeatureWrapper>
     }
     return (<FeatureWrapper {...wrapperParams}>

--- a/src/components/features/composite/composite.tsx
+++ b/src/components/features/composite/composite.tsx
@@ -12,6 +12,7 @@ type CompositeType = "composite" | "light" | "switch" | "cover" | "lock" | "fan"
 
 interface CompositeProps extends BaseFeatureProps<CompositeFeature> {
     type: CompositeType;
+    depth?: number;
     stepsConfiguration?: Record<string, unknown>;
     minimal?: boolean;
     showEndpointLabels?: boolean;
@@ -69,6 +70,7 @@ export class Composite extends Component<CompositeProps & WithTranslation<"compo
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const { t, showEndpointLabels = false, feature, device, deviceState, onRead: _onRead, onChange: _onChange, featureWrapperClass, minimal } = this.props;
         const { features = [] } = feature;
+        const depth = this.props.depth ?? 0;
         const { state } = this;
         const isThisACompositeFeature = isCompositeFeature(feature)
         const isMoreThanOneFeature = features.length > 1;
@@ -84,6 +86,7 @@ export class Composite extends Component<CompositeProps & WithTranslation<"compo
                     feature={f}
                     device={device}
                     deviceState={combinedState}
+                    depth={depth + 1}
                     onChange={this.onChange}
                     onRead={this.onRead}
                     featureWrapperClass={featureWrapperClass}
@@ -98,6 +101,7 @@ export class Composite extends Component<CompositeProps & WithTranslation<"compo
                     feature={f}
                     device={device}
                     deviceState={combinedState}
+                    depth={depth + 1}
                     onChange={this.onChange}
                     onRead={this.onRead}
                     featureWrapperClass={featureWrapperClass}
@@ -109,6 +113,7 @@ export class Composite extends Component<CompositeProps & WithTranslation<"compo
                 key={JSON.stringify(f)}
                 feature={f}
                 device={device}
+                depth={depth + 1}
                 deviceState={combinedState}
                 onChange={this.onChange}
                 onRead={this.onRead}
@@ -119,7 +124,7 @@ export class Composite extends Component<CompositeProps & WithTranslation<"compo
         }
 
 
-        if (isThisACompositeFeature && isMoreThanOneFeature) {
+        if (isThisACompositeFeature && isMoreThanOneFeature && depth === 1) {
             result.push(<div key={feature.name + 'apply'}>
                 <Button disabled={!this.allInnerFeaturesHaveValues()} className={cx('btn btn-primary float-end', { 'btn-sm': minimal })} onClick={this.onCompositeFeatureApply}>{t('common:apply')}</Button>
             </div>)


### PR DESCRIPTION
For: https://github.com/Koenkk/zigbee-herdsman-converters/pull/5058 and https://github.com/Koenkk/zigbee-herdsman-converters/pull/5298 (CC: @protyposis, @mdziekon)

- Removes the apply button for nested composites (one apply button on the root composite is always shown now)
- Fix apply button always greyed out for nested composites, apply button on root composite will be enabled when all child composites are filled in
- Used the following expose (requires a small change in zigbee-herdsman-converters, access needs to be added for composite)

```js
exposes.composite('schedule_settings_composite', 'schedule_settings_composite', ea.ALL)
    .withFeature(exposes.composite('Days', 'days')
        .withFeature(exposes.switch().withState('mon', true, undefined, ea.STATE_SET))
        .withFeature(exposes.switch().withState('tue', true, undefined, ea.STATE_SET))
        .withFeature(exposes.switch().withState('wed', true, undefined, ea.STATE_SET))
        .withFeature(exposes.switch().withState('thu', true, undefined, ea.STATE_SET))
        .withFeature(exposes.switch().withState('fri', true, undefined, ea.STATE_SET))
        .withFeature(exposes.switch().withState('sat', true, undefined, ea.STATE_SET))
        .withFeature(exposes.switch().withState('sun', true, undefined, ea.STATE_SET)),
    )
    .withFeature(exposes.composite('Start', 'start')
        .withFeature(exposes.numeric('Hour', ea.STATE_SET).withProperty('hour'))
        .withFeature(exposes.numeric('Minute', ea.STATE_SET).withProperty('minute'))
        .withFeature(exposes.numeric('Temperature', ea.STATE_SET).withProperty('temperature')))
    .withFeature(exposes.composite('Intermediate 1', 'intermediate1')
        .withFeature(exposes.numeric('Hour', ea.STATE_SET).withProperty('hour'))
        .withFeature(exposes.numeric('Minute', ea.STATE_SET).withProperty('minute'))
        .withFeature(exposes.numeric('Temperature', ea.STATE_SET).withProperty('temperature')))
    .withFeature(exposes.composite('Intermediate 2', 'intermediate2')
        .withFeature(exposes.numeric('Hour', ea.STATE_SET).withProperty('hour'))
        .withFeature(exposes.numeric('Minute', ea.STATE_SET).withProperty('minute'))
        .withFeature(exposes.numeric('Temperature', ea.STATE_SET).withProperty('temperature')))
    .withFeature(exposes.composite('End', 'end')
        .withFeature(exposes.numeric('Hour', ea.STATE_SET).withProperty('hour'))
        .withFeature(exposes.numeric('Minute', ea.STATE_SET).withProperty('minute'))
        .withFeature(exposes.numeric('Temperature', ea.STATE_SET).withProperty('temperature')))
    .withDescription('Smart schedule configuration'),
```

- Example:

![image](https://user-images.githubusercontent.com/2892853/209364431-6cf3e1cb-0567-4bde-91af-331c77629f14.png)
