### PR TITLE
fix(attribute-picker): picking "select attribute" crashes

### DIFF
--- a/src/components/attribute-picker/index.tsx
+++ b/src/components/attribute-picker/index.tsx
@@ -26,10 +26,11 @@ export default function AttributePicker(props: AttributePickerProps & Omit<Input
         const { value: inputValue } = e.target;
         const currentCluster = Clusters[cluster];
         const attributeInfo = currentCluster.attributes[inputValue]
-        onChange(inputValue, attributeInfo);
+        // inputValue could be "Select attribute" which isn't a proper cluster attribute
+        if (attributeInfo) {
+            onChange(inputValue, attributeInfo);
+        }
     }
-
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
 
     let attrs = [] as string[];
     const clusterDefinition = Clusters[cluster];


### PR DESCRIPTION
On Safari, the `hidden` "Select attribute" still shows up 😓 

If accidentally selected by the user, `onChange` is called with `attributeInfo === undefined`.

This PR handles that edge case.