### PR TITLE
fix(range-editor): send value on stepper click

### DIFF
--- a/src/components/range-editor/range-editor.tsx
+++ b/src/components/range-editor/range-editor.tsx
@@ -43,6 +43,7 @@ const RangeEditor: FunctionComponent<RangeProps & Omit<InputHTMLAttributes<HTMLI
             step={valueStep}
             onChange={e => setCurrentValue(e.target.valueAsNumber)}
             onBlur={() => onChange(currentValue)}
+            onMouseUp={() => onChange(currentValue)}
             min={min}
             max={max}
             {...rest}


### PR DESCRIPTION
This PR adds `onMouseUp` event to the number input of `RangeEditor´ to fix a missing change event.

Currently, if a user changes the value of a range editor by clicking on the arrows of the stepper, the value in the UI changes (slider position and textual value), but no change event is triggered.
This is a bit confusing.