### PR TITLE
fix(i18n): simplified Chinese auto detect

### DIFF
--- a/src/i18n/LocalePicker.tsx
+++ b/src/i18n/LocalePicker.tsx
@@ -39,7 +39,7 @@ const localesMap = {
     ptbr,
     es,
     ua,
-    chs,
+    "zh-CN": chs,
     nl,
     it,
     zh,
@@ -80,7 +80,7 @@ export default function LocalePicker(): JSX.Element {
             <span className="align-middle">{localeNames[language]}</span>
         </a>
     ));
-    const currentLanguage = i18n.language.split('-')[0];
+    const currentLanguage = localesMap[i18n.language] ? i18n.language : i18n.language.split('-')[0];
 
     return (
         <li className="nav-item dropdown">

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -55,7 +55,7 @@ register("ru", timeRu);
 register("ptbr", timePtBr);
 register("es", timeEs);
 register("ua", timeUa);
-register("chs", timeChs);
+register("zh-CN", timeChs);
 register("nl", timeNl);
 register("it", timeIt);
 register("ko", timeKo);
@@ -81,7 +81,7 @@ export const resources = {
     ptbr: ptbrTranslations as ResourceLanguage,
     es: esTranslations as ResourceLanguage,
     ua: uaTranslations as ResourceLanguage,
-    chs: chsTranslations as ResourceLanguage,
+    "zh-CN": chsTranslations as ResourceLanguage,
     nl: nlTranslations as ResourceLanguage,
     it: itTranslations as ResourceLanguage,
     zh: zhTranslations as ResourceLanguage,

--- a/src/i18n/locales/localeNames.json
+++ b/src/i18n/locales/localeNames.json
@@ -8,7 +8,7 @@
     "ptbr": "Brazilian Portuguese",
     "ru": "Русский",
     "ua": "Українська",
-    "chs": "简体中文",
+    "zh-CN": "简体中文",
     "it": "Italiano",
     "zh": "繁體中文",
     "ko": "한국어",


### PR DESCRIPTION
```
i18n.language:"zh-CN"
i18n.languages:Array(3) 0: "zh-CN" 1: "zh" 2: "en"
```
If `zh-CN` does not exist, `zh` will be used, resulting in traditional Chinese, so we need to change `chs` to `zh-CN`.