### PR TITLE
feat(expose): use label name in expose

### DIFF
--- a/src/components/features/composite/Feature.tsx
+++ b/src/components/features/composite/Feature.tsx
@@ -69,7 +69,7 @@ export const Feature = (props: FeatureProps): JSX.Element => {
         minimal,
         parentFeatures,
     };
-    const wrapperParams = { key: JSON.stringify(feature), feature, onRead, deviceState };
+    const wrapperParams = { key: JSON.stringify(feature), feature, onRead, deviceState, parentFeatures };
 
     if (isBinaryFeature(feature)) {
         return (

--- a/src/components/features/composite/FeatureWrapper.tsx
+++ b/src/components/features/composite/FeatureWrapper.tsx
@@ -6,6 +6,7 @@ import { isColorFeature } from '../../device-page/type-guards';
 
 export type FeatureWrapperProps = {
     feature: CompositeFeature | GenericExposedFeature;
+    parentFeatures: (CompositeFeature | GenericExposedFeature)[];
     deviceState?: DeviceState;
     onRead(endpoint: Endpoint, property: Record<string, unknown>): void;
 };
@@ -14,13 +15,19 @@ export const FeatureWrapper: FunctionComponent<PropsWithChildren<FeatureWrapperP
     const { children, feature, onRead } = props;
     const isColor = isColorFeature(feature);
     const isReadable = (feature.property && feature.access & FeatureAccessMode.ACCESS_READ) || isColor;
+
+    const parentFeature = props.parentFeatures?.[props.parentFeatures.length - 1]
+    let label = feature.label;
+    if (feature.name === 'state' && !['light', 'switch'].includes(parentFeature.type)) {
+        label = `${parentFeature.label} ${feature.label.charAt(0).toLowerCase()}${feature.label.slice(1)}`;
+    }
+
+    // if (feature.name === 'state')
     const leftColumn = (
         <div className="col-12 col-md-3">
             <label className="col-form-label w-100">
                 <div className="d-flex justify-content-between">
-                    <strong title={JSON.stringify(feature)}>
-                        {feature.name === 'state' ? feature.property : feature.name}
-                    </strong>
+                    <strong title={JSON.stringify(feature)}>{label}</strong>
                     {isReadable ? (
                         <Button<CompositeFeature | GenericExposedFeature>
                             item={feature}

--- a/src/components/features/composite/FeatureWrapper.tsx
+++ b/src/components/features/composite/FeatureWrapper.tsx
@@ -22,7 +22,6 @@ export const FeatureWrapper: FunctionComponent<PropsWithChildren<FeatureWrapperP
         label = `${parentFeature.label} ${feature.label.charAt(0).toLowerCase()}${feature.label.slice(1)}`;
     }
 
-    // if (feature.name === 'state')
     const leftColumn = (
         <div className="col-12 col-md-3">
             <label className="col-form-label w-100">

--- a/src/types.ts
+++ b/src/types.ts
@@ -110,6 +110,7 @@ export enum FeatureAccessMode {
 export interface GenericExposedFeature {
     type: GenericFeatureType;
     name: string;
+    label: string;
     unit?: "string";
     access: FeatureAccessMode;
     endpoint?: Endpoint;


### PR DESCRIPTION
Use label expose implemented in https://github.com/Koenkk/zigbee-herdsman-converters/pull/6066 by @drafteed

After this the expose page looks more user friendly:

Before             |  After
:-------------------------:|:-------------------------:
![](https://github.com/nurikk/zigbee2mqtt-frontend/assets/2892853/b6d0d327-104a-4181-b6e5-ee85b739dd68)  |  ![](https://github.com/nurikk/zigbee2mqtt-frontend/assets/2892853/4f578d75-e09c-42e8-92db-4aebd4626850)
