### PR TITLE
feat: dropdown adjusts to available space

### DIFF
--- a/src/hooks/useComponentVisible.tsx
+++ b/src/hooks/useComponentVisible.tsx
@@ -25,5 +25,23 @@ export default function useComponentVisible(initialIsVisible: boolean) {
         };
     });
 
+    useEffect(() => {
+        if (!isComponentVisible || !ref.current || !ref.current?.parentElement) {
+            return;
+        }
+
+        // show on top
+        if (ref.current.clientHeight + ref.current.parentElement.offsetTop > window.screen.height + window.scrollY) {
+            ref.current.parentElement.style.position = 'relative';
+            ref.current.style.position = 'absolute';
+            ref.current.style.bottom = '0';
+            return;
+        }
+
+        // fall back to default
+        ref.current.parentElement.style.position = '';
+        ref.current.style.position = '';
+        ref.current.style.bottom = '';
+    }, [isComponentVisible]);
     return { ref, isComponentVisible, setIsComponentVisible };
 }


### PR DESCRIPTION
Hello there,

at this place I want to say thanks for the fantastic work!

I'm experiencing a issue on smaller screens (iPhone SE to be exact) where the drop downs can't be fully displayed because the screen size is too small and the drop downs have a fixed height. I think the screenshoots explain it best.

Before:
![2023-09-15 14 54 33](https://github.com/nurikk/zigbee2mqtt-frontend/assets/49675685/83dbafe6-cb14-4cc2-8962-c3c0eae13c5c)

Some languages are cut and I'm not able to select them.
After:
![2023-09-15 14 54 28](https://github.com/nurikk/zigbee2mqtt-frontend/assets/49675685/028fa498-af51-4507-855b-4f526820d2b3)
Adaption to available height.

I hope this isn't breaking anything :) 