### PR TITLE
feat(scrolltotop): add ScrollToTop component

### DIFF
--- a/src/components/scroll-to-top.tsx
+++ b/src/components/scroll-to-top.tsx
@@ -1,0 +1,11 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+export default function ScrollToTop() {
+    const { pathname } = useLocation();
+    useEffect(() => {
+        document.getElementsByTagName('main')?.[0]?.scrollTo(0, 0);
+    }, [pathname]);
+
+    return null;
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -29,6 +29,7 @@ import ErrorBoundary from './components/ErrorBoundary';
 import DashboardPage from './components/dashboard-page';
 import ExtensionsEditorPage from './components/extensions-editor';
 import GroupPage from './components/groups/GroupPage';
+import ScrollToTop from './components/scroll-to-top';
 
 import { ThemeSwitcherProvider } from 'react-css-theme-switcher';
 import i18n from './i18n';
@@ -55,6 +56,7 @@ const Main = () => {
                     <Provider store={store}>
                         <ThemeSwitcherProvider themeMap={themes} defaultTheme={theme}>
                             <HashRouter>
+                                <ScrollToTop />
                                 <div className="main">
                                     <NavBar />
                                     <main className="content p-0 p-sm-3">


### PR DESCRIPTION
This PR scrolls the `<main>` container back to the top on a navigation change.

It currently does not implement back button scroll restoration. It might be a good idea to migrate to React Router 6 which has a component that does it all: https://reactrouter.com/en/main/components/scroll-restoration 

