### PR TITLE
feat(memoize-table-columns): memoize device list table columns

### DIFF
--- a/src/components/zigbee/DevicesTable.tsx
+++ b/src/components/zigbee/DevicesTable.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import style from './style.module.css';
 import { genDeviceDetailsLink, lastSeen, toHex } from '../../utils';
 import { useTranslation } from 'react-i18next';
@@ -72,7 +72,7 @@ export function DevicesTable(
               },
           ]
         : [];
-    const columns = [
+    const columns = useMemo(() => [
         {
             id: 'pic',
             Header: t('pic'),
@@ -182,7 +182,7 @@ export function DevicesTable(
             },
             disableSortBy: true,
         },
-    ];
+    ], []);
 
     return (
         <div className="card">


### PR DESCRIPTION
This PR memoizes the columns in the device list. It helps quite a bit against the flickering I talked about in https://github.com/nurikk/zigbee2mqtt-frontend/issues/1840

