### PR TITLE
Fix ota zigbee_ota_override_index_location property to support null value

### DIFF
--- a/ws-messages/onConnect.json
+++ b/ws-messages/onConnect.json
@@ -1010,7 +1010,10 @@
                                 ],
                                 "requiresRestart": true,
                                 "title": "OTA index override file name",
-                                "type": "string"
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
                             }
                         },
                         "title": "OTA updates",


### PR DESCRIPTION
Fix can't revert to empty value after use custom value in 'OTA index override file name'