### PR TITLE
fix typo in german locale

### DIFF
--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -2225,7 +2225,7 @@
         "firmware_version": "Firmware-Version",
         "force_remove": "Erzwinge entfernen",
         "friendly_name": "Gerätename",
-        "ieee_address": "IEEE-Addresse",
+        "ieee_address": "IEEE-Adresse",
         "input_clusters": "Eingabe-Cluster",
         "interview_completed": "Interview erfolgreich",
         "interview_failed": "Interview fehlgeschlagen",


### PR DESCRIPTION
The german equivalent for the english word "address" in written with only one "d".