### PR TITLE
fix: programming_mode dosnt show values

### DIFF
--- a/src/components/features/composite/Feature.tsx
+++ b/src/components/features/composite/Feature.tsx
@@ -133,7 +133,7 @@ export const Feature = (props: FeatureProps): JSX.Element => {
         // When parent is a list (this is when parentFeatures is not set), we don't
         // need to take the key of the deviceState (deviceState[feature.property])
         const deviceState_ = parentFeatures
-            ? feature.property
+            ? feature.property && !["programming_mode"].includes(feature.property)
                 ? deviceState[feature.property]
                 : deviceState
             : deviceState;


### PR DESCRIPTION
The radiator thermostat(_TZE200_cpmgn2cf) dosn't show current values for 'programming_mode'-list.
![image](https://github.com/nurikk/zigbee2mqtt-frontend/assets/105419325/931c657d-fb20-4796-8b1d-7640697aff6c)

Expected:
![image](https://github.com/nurikk/zigbee2mqtt-frontend/assets/105419325/d9565c5e-d4eb-4178-b829-4e7011e2899a)
