### PR TITLE
feat(ui): allow display illuminance_lux in dashboard

### DIFF
--- a/src/components/dashboard-page/index.tsx
+++ b/src/components/dashboard-page/index.tsx
@@ -27,7 +27,6 @@ const genericRendererIgnoredNames = [
     'battery',
     'battery_low',
     'battery_state',
-//    'illuminance_lux',
     'color_temp_startup',
     'voltage',
     'strength',

--- a/src/components/dashboard-page/index.tsx
+++ b/src/components/dashboard-page/index.tsx
@@ -27,7 +27,7 @@ const genericRendererIgnoredNames = [
     'battery',
     'battery_low',
     'battery_state',
-    'illuminance_lux',
+//    'illuminance_lux',
     'color_temp_startup',
     'voltage',
     'strength',


### PR DESCRIPTION
I don't see a reason why a JSON state field `illuminance_lux` can't be displayed in Dashboard (especially when `illuminance` is) for a device.

I'm an owner of [this](https://www.zigbee2mqtt.io/devices/ZG-205ZL.html#tuya-zg-205zl) and [this](https://www.zigbee2mqtt.io/devices/ZG-204ZL.html#tuya-zg-204zl) devices and I would like to see Illuminance value for both devices in the dashboard.

If there is a good reason for current state, can you point me out to the decision made or provide details for that please? In such a case I probably would think how to implement that in a better shape.