### PR TITLE
chore(dev-console): move  ExternalDefinition and AnttributeEditor to new files

### DIFF
--- a/src/actions/DeviceApi.ts
+++ b/src/actions/DeviceApi.ts
@@ -1,5 +1,5 @@
 import api from "../ws-client";
-import { AttributeInfo } from "../components/device-page/dev-console";
+import { AttributeInfo } from '../components/device-page/AttributeEditor';
 import { Attribute, Cluster, Endpoint, FriendlyName, IEEEEAddress } from "../types";
 import { toDeviceId } from "./actions";
 

--- a/src/components/device-page/AttributeEditor.tsx
+++ b/src/components/device-page/AttributeEditor.tsx
@@ -1,0 +1,225 @@
+import React, { ChangeEvent } from 'react';
+import { Attribute, Cluster, Device, Endpoint } from '../../types';
+import ClusterPicker, { PickerType } from '../cluster-picker';
+import ZclCluster from 'zigbee-herdsman/dist/zcl/definition/cluster';
+import AttributePicker, { AttributeDefinition } from '../attribute-picker';
+import Button from '../button';
+import { GlobalState, LogMessage } from '../../store';
+import EndpointPicker from '../endpoint-picker';
+import { getEndpoints } from '../../utils';
+import { LastLogResult } from './LastLogResult';
+import { WithTranslation, withTranslation } from 'react-i18next';
+import { DeviceApi } from '../../actions/DeviceApi';
+import DataType from 'zigbee-herdsman/dist/zcl/definition/dataType';
+
+export interface AttributeEditorProps
+    extends WithTranslation,
+        Pick<DeviceApi, 'executeCommand' | 'readDeviceAttributes' | 'writeDeviceAttributes'>,
+        Pick<GlobalState, 'theme'> {
+    device: Device;
+    logs: LogMessage[];
+}
+export type AttributeInfo = {
+    attribute: Attribute;
+    definition: AttributeDefinition;
+    value?: unknown;
+};
+
+export type AttributeEditorState = {
+    cluster: Cluster;
+    endpoint: Endpoint;
+    attributes: AttributeInfo[];
+    mode: Mode;
+};
+
+export type Mode = 'read' | 'write';
+
+export type AttributeValueInputProps = {
+    onChange(attribute: Attribute, value: unknown): void;
+    attribute: Attribute;
+    definition: AttributeDefinition;
+    value?: unknown;
+};
+
+function AttributeValueInput(props: AttributeValueInputProps): JSX.Element {
+    const { value, onChange, attribute, definition } = props;
+    const typesMap = {
+        [DataType.charStr]: 'string',
+        [DataType.longCharStr]: 'string',
+    };
+    const type = typesMap[definition.type] ?? 'number';
+
+    const onValueChanged = (e: ChangeEvent<HTMLInputElement>): void => {
+        const val = type === 'number' ? e.target.valueAsNumber : e.target.value;
+        onChange(attribute, val);
+    };
+
+    return <input className="form-control" type={type} value={value as string | number} onChange={onValueChanged} />;
+}
+const logStartingStrings = ['Read result of', "Publish 'set' 'read' to", "Publish 'set' 'write' to", 'Wrote '];
+
+class AttributeEditor extends React.Component<AttributeEditorProps, AttributeEditorState> {
+    constructor(props: AttributeEditorProps) {
+        super(props);
+        const { device } = props;
+        const defaultEndpoint = Object.keys(device.endpoints)[0];
+        this.state = {
+            endpoint: defaultEndpoint,
+            cluster: '',
+            attributes: [],
+            mode: 'read',
+        };
+    }
+
+    canRead = (): boolean => {
+        const { cluster, attributes, endpoint } = this.state;
+        return !!endpoint && attributes.length > 0 && !!cluster;
+    };
+
+    onEndpointChange = (endpoint: Endpoint): void => {
+        this.setState({ attributes: [], cluster: '', endpoint });
+    };
+
+    onClusterChange = (cluster: Cluster): void => {
+        this.setState({ attributes: [], cluster });
+    };
+
+    onAttributeSelect = (attribute: Attribute, definition: AttributeDefinition): void => {
+        const { attributes } = this.state;
+        if (!attributes.find((info) => info.attribute === attribute)) {
+            const newAttributes = attributes.concat([{ attribute, definition }]);
+            this.setState({ attributes: newAttributes });
+        }
+    };
+
+    onAttributeDelete = (attribute: Attribute): void => {
+        const { attributes } = this.state;
+        const newAttributes = attributes.filter((info) => info.attribute !== attribute);
+        this.setState({ attributes: newAttributes });
+    };
+
+    onReadClick = (): void => {
+        const { readDeviceAttributes, device } = this.props;
+        const { cluster, attributes, endpoint } = this.state;
+        readDeviceAttributes(
+            device.friendly_name,
+            endpoint,
+            cluster,
+            attributes.map((info) => info.attribute),
+            {},
+        );
+    };
+
+    onWriteClick = (): void => {
+        const { writeDeviceAttributes, device } = this.props;
+        const { cluster, attributes, endpoint } = this.state;
+        writeDeviceAttributes(device.friendly_name, endpoint, cluster, attributes, {});
+    };
+
+    onAttributeValueChange = (attribute: Attribute, value: unknown): void => {
+        const { attributes } = this.state;
+        const newAttributes = [...attributes];
+        const attr = newAttributes.find((info) => info.attribute === attribute);
+        if (attr) {
+            attr.value = value;
+        }
+        this.setState({ attributes: newAttributes });
+    };
+
+    renderSelectedAttribute(): JSX.Element[] {
+        const { attributes } = this.state;
+        return attributes.map(({ attribute, value = '', definition }) => (
+            <div key={attribute} className="row mb-1">
+                <div className="col-3">
+                    <div className="row">
+                        <div className="col-6">{attribute}</div>
+                        <div className="col-3">
+                            <AttributeValueInput
+                                value={value as string | number}
+                                attribute={attribute}
+                                definition={definition}
+                                onChange={this.onAttributeValueChange}
+                            />
+                        </div>
+                        <div className="col-2">
+                            <Button<Attribute>
+                                className="btn btn-danger btn-sm"
+                                item={attribute}
+                                onClick={this.onAttributeDelete}
+                            >
+                                <i className="fas fa-trash" />
+                            </Button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        ));
+    }
+    setMode = (mode: Mode): void => {
+        this.setState({ mode });
+    };
+
+    render() {
+        const { cluster, attributes, endpoint } = this.state;
+        const noAttributesSelected = attributes.length === 0;
+        const noSelectedCluster = cluster === '';
+        const { t, device } = this.props;
+        const endpoints = getEndpoints(device);
+        const logsFilterFn = (l: LogMessage) =>
+            logStartingStrings.some((startString) => l.message.startsWith(startString));
+        return (
+            <>
+                <div className="mb-3 row">
+                    <div className="col-6 col-sm-3">
+                        <EndpointPicker
+                            label={t('zigbee:endpoint')}
+                            values={endpoints}
+                            value={endpoint as Endpoint}
+                            onChange={this.onEndpointChange}
+                        />
+                    </div>
+                    <div className="col-6 col-sm-3">
+                        <ClusterPicker
+                            label={t('cluster')}
+                            pickerType={PickerType.SINGLE}
+                            clusters={Object.keys(ZclCluster)}
+                            value={cluster}
+                            onChange={this.onClusterChange}
+                        />
+                    </div>
+
+                    <div className="col-6 col-sm-3">
+                        <AttributePicker
+                            label={t('attribute')}
+                            value={''}
+                            cluster={cluster}
+                            onChange={this.onAttributeSelect}
+                        />
+                    </div>
+                </div>
+                <div className="mb-3 row">{this.renderSelectedAttribute()}</div>
+                <div className="mb-3 row">
+                    <div className="btn-group col col-3" role="group">
+                        <Button<void>
+                            disabled={noAttributesSelected || noSelectedCluster}
+                            className="btn btn-success me-2"
+                            onClick={this.onReadClick}
+                        >
+                            {t('read')}
+                        </Button>
+                        <Button<void>
+                            disabled={noAttributesSelected || noSelectedCluster}
+                            className="btn btn-danger"
+                            onClick={this.onWriteClick}
+                        >
+                            {t('write')}
+                        </Button>
+                    </div>
+                </div>
+                <LastLogResult logs={this.props.logs} filterFn={logsFilterFn} />
+            </>
+        );
+    }
+}
+
+export default withTranslation(['devConsole', 'common'])(AttributeEditor);

--- a/src/components/device-page/ExternalDefinition.tsx
+++ b/src/components/device-page/ExternalDefinition.tsx
@@ -1,0 +1,59 @@
+import { WithTranslation, withTranslation } from 'react-i18next';
+import { DeviceApi } from '../../actions/DeviceApi';
+import { GlobalState } from '../../store';
+import { Device } from '../../types';
+import React from 'react';
+import AceEditor from 'react-ace';
+import { supportNewDevicesUrl } from '../../utils';
+import Button from '../button';
+
+export interface ExternalDefinitionProps
+    extends WithTranslation,
+        Pick<DeviceApi, 'generateExternalDefinition'>,
+        Pick<GlobalState, 'generatedExternalDefinitions' | 'theme'> {
+    device: Device;
+}
+
+class ExternalDefinition extends React.Component<ExternalDefinitionProps, {}> {
+    onGenerateExternalDefinitionClick = (): void => {
+        const { generateExternalDefinition, device } = this.props;
+        generateExternalDefinition(device.ieee_address);
+    };
+
+    render(): JSX.Element {
+        const { t, generatedExternalDefinitions, device, theme } = this.props;
+        const externalDefinition = generatedExternalDefinitions[device.ieee_address];
+        if (externalDefinition) {
+            const editorTheme = theme === 'light' ? 'github' : 'dracula';
+            return (
+                <>
+                    {t('generated_external_definition')} (
+                    <a href={supportNewDevicesUrl} target="_blank" rel="noreferrer">
+                        {t('documentation')}
+                    </a>
+                    )
+                    <AceEditor
+                        setOptions={{ useWorker: false }}
+                        mode="javascript"
+                        readOnly={true}
+                        name="UNIQUE_ID_OF_DIV"
+                        editorProps={{ $blockScrolling: true }}
+                        value={externalDefinition}
+                        width="100%"
+                        maxLines={Infinity}
+                        theme={editorTheme}
+                        showPrintMargin={false}
+                    />
+                </>
+            );
+        } else {
+            return (
+                <Button<void> className="btn btn-primary" onClick={this.onGenerateExternalDefinitionClick}>
+                    {t('generate_external_definition')}
+                </Button>
+            );
+        }
+    }
+}
+
+export default withTranslation(['devConsole', 'common'])(ExternalDefinition);

--- a/src/components/device-page/dev-console.tsx
+++ b/src/components/device-page/dev-console.tsx
@@ -1,20 +1,14 @@
-import React, { ChangeEvent, Component } from 'react';
-import { Attribute, Cluster, Device, Endpoint } from '../../types';
-import ClusterPicker, { PickerType } from '../cluster-picker';
+import React, { Component } from 'react';
+import { Cluster, Device, Endpoint } from '../../types';
 
-import DataType from 'zigbee-herdsman/dist/zcl/definition/dataType';
-import ZclCluster from 'zigbee-herdsman/dist/zcl/definition/cluster';
-import AttributePicker, { AttributeDefinition } from '../attribute-picker';
 import Button from '../button';
 import { DeviceApi } from '../../actions/DeviceApi';
 import { GlobalState, LogMessage } from '../../store';
 import { WithTranslation, withTranslation } from 'react-i18next';
-import EndpointPicker from '../endpoint-picker';
-import { getEndpoints } from '../../utils';
 import { CommandExecutor } from './CommandExecutor';
-import { LastLogResult } from './LastLogResult';
 import ExternalDefinition from './ExternalDefinition';
 import { Theme } from '@rjsf/bootstrap-5';
+import AttributeEditor from './AttributeEditor';
 
 interface DevConsoleProps
     extends WithTranslation,
@@ -26,215 +20,33 @@ interface DevConsoleProps
     device: Device;
     logs: LogMessage[];
 }
-export type AttributeInfo = {
-    attribute: Attribute;
-    definition: AttributeDefinition;
-    value?: unknown;
-};
-type DevConsoleState = {
-    cluster: Cluster;
-    endpoint: Endpoint;
-    attributes: AttributeInfo[];
-    mode: Mode;
-};
 
-type Mode = 'read' | 'write';
-
-type AttributeValueEditorProps = {
-    onChange(attribute: Attribute, value: unknown): void;
-    attribute: Attribute;
-    definition: AttributeDefinition;
-    value?: unknown;
-};
-function AttributeValueEditor(props: AttributeValueEditorProps): JSX.Element {
-    const { value, onChange, attribute, definition } = props;
-    const typesMap = {
-        [DataType.charStr]: 'string',
-        [DataType.longCharStr]: 'string',
-    };
-    const type = typesMap[definition.type] ?? 'number';
-
-    const onValueChanged = (e: ChangeEvent<HTMLInputElement>): void => {
-        const val = type === 'number' ? e.target.valueAsNumber : e.target.value;
-        onChange(attribute, val);
-    };
-
-    return <input className="form-control" type={type} value={value as string | number} onChange={onValueChanged} />;
-}
-const logStartingStrings = ['Read result of', "Publish 'set' 'read' to", "Publish 'set' 'write' to", 'Wrote '];
-
-export class DevConsole extends Component<DevConsoleProps, DevConsoleState> {
-    constructor(props: DevConsoleProps) {
-        super(props);
-        const { device } = props;
-        const defaultEndpoint = Object.keys(device.endpoints)[0];
-        this.state = {
-            endpoint: defaultEndpoint,
-            cluster: '',
-            attributes: [],
-            mode: 'read',
-        };
-    }
-    canRead = (): boolean => {
-        const { cluster, attributes, endpoint } = this.state;
-        return !!endpoint && attributes.length > 0 && !!cluster;
-    };
-    onEndpointChange = (endpoint: Endpoint): void => {
-        this.setState({ attributes: [], cluster: '', endpoint });
-    };
-
-    onClusterChange = (cluster: Cluster): void => {
-        this.setState({ attributes: [], cluster });
-    };
-    onAttributeSelect = (attribute: Attribute, definition: AttributeDefinition): void => {
-        const { attributes } = this.state;
-        if (!attributes.find((info) => info.attribute === attribute)) {
-            const newAttributes = attributes.concat([{ attribute, definition }]);
-            this.setState({ attributes: newAttributes });
-        }
-    };
-    onAttributeDelete = (attribute: Attribute): void => {
-        const { attributes } = this.state;
-        const newAttributes = attributes.filter((info) => info.attribute !== attribute);
-        this.setState({ attributes: newAttributes });
-    };
-    onReadClick = (): void => {
-        const { readDeviceAttributes, device } = this.props;
-        const { cluster, attributes, endpoint } = this.state;
-        readDeviceAttributes(
-            device.friendly_name,
-            endpoint,
-            cluster,
-            attributes.map((info) => info.attribute),
-            {},
-        );
-    };
-
-    onWriteClick = (): void => {
-        const { writeDeviceAttributes, device } = this.props;
-        const { cluster, attributes, endpoint } = this.state;
-        writeDeviceAttributes(device.friendly_name, endpoint, cluster, attributes, {});
-    };
-
-    onAttributeValueChange = (attribute: Attribute, value: unknown): void => {
-        const { attributes } = this.state;
-        const newAttributes = [...attributes];
-        const attr = newAttributes.find((info) => info.attribute === attribute);
-        if (attr) {
-            attr.value = value;
-        }
-        this.setState({ attributes: newAttributes });
-    };
-
-    renderSelectedAttribute(): JSX.Element[] {
-        const { attributes } = this.state;
-        return attributes.map(({ attribute, value = '', definition }) => (
-            <div key={attribute} className="row mb-1">
-                <div className="col-3">
-                    <div className="row">
-                        <div className="col-6">{attribute}</div>
-                        <div className="col-3">
-                            <AttributeValueEditor
-                                value={value as string | number}
-                                attribute={attribute}
-                                definition={definition}
-                                onChange={this.onAttributeValueChange}
-                            />
-                        </div>
-                        <div className="col-2">
-                            <Button<Attribute>
-                                className="btn btn-danger btn-sm"
-                                item={attribute}
-                                onClick={this.onAttributeDelete}
-                            >
-                                <i className="fas fa-trash" />
-                            </Button>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        ));
-    }
-    setMode = (mode: Mode): void => {
-        this.setState({ mode });
-    };
-    renderRead(): JSX.Element {
-        const { cluster, attributes, endpoint } = this.state;
-        const noAttributesSelected = attributes.length === 0;
-        const noSelectedCluster = cluster === '';
-        const { t, device } = this.props;
-        const endpoints = getEndpoints(device);
-        const logsFilterFn = (l: LogMessage) =>
-            logStartingStrings.some((startString) => l.message.startsWith(startString));
-        return (
-            <>
-                <div className="mb-3 row">
-                    <div className="col-6 col-sm-3">
-                        <EndpointPicker
-                            label={t('zigbee:endpoint')}
-                            values={endpoints}
-                            value={endpoint as Endpoint}
-                            onChange={this.onEndpointChange}
-                        />
-                    </div>
-                    <div className="col-6 col-sm-3">
-                        <ClusterPicker
-                            label={t('cluster')}
-                            pickerType={PickerType.SINGLE}
-                            clusters={Object.keys(ZclCluster)}
-                            value={cluster}
-                            onChange={this.onClusterChange}
-                        />
-                    </div>
-
-                    <div className="col-6 col-sm-3">
-                        <AttributePicker
-                            label={t('attribute')}
-                            value={''}
-                            cluster={cluster}
-                            onChange={this.onAttributeSelect}
-                        />
-                    </div>
-                </div>
-                <div className="mb-3 row">{this.renderSelectedAttribute()}</div>
-                <div className="mb-3 row">
-                    <div className="btn-group col col-3" role="group">
-                        <Button<void>
-                            disabled={noAttributesSelected || noSelectedCluster}
-                            className="btn btn-success me-2"
-                            onClick={this.onReadClick}
-                        >
-                            {t('read')}
-                        </Button>
-                        <Button<void>
-                            disabled={noAttributesSelected || noSelectedCluster}
-                            className="btn btn-danger"
-                            onClick={this.onWriteClick}
-                        >
-                            {t('write')}
-                        </Button>
-                    </div>
-                </div>
-                <LastLogResult logs={this.props.logs} filterFn={logsFilterFn} />
-            </>
-        );
-    }
-
+export class DevConsole extends Component<DevConsoleProps, {}> {
     render(): JSX.Element {
         return (
             <div>
                 <div className="card">
                     <div className="card-body">
                         <ExternalDefinition
-                            device={this.props.device}
                             theme={this.props.theme}
+                            device={this.props.device}
                             generateExternalDefinition={this.props.generateExternalDefinition}
                             generatedExternalDefinitions={this.props.generatedExternalDefinitions}
                         />
                     </div>
                 </div>
                 <div className="card">
-                    <div className="card-body">{this.renderRead()}</div>
+                    <div className="card-body">
+                        <AttributeEditor
+                            theme={this.props.theme}
+                            device={this.props.device}
+                            logs={this.props.logs}
+                            i18n={this.props.i18n}
+                            executeCommand={this.props.executeCommand}
+                            readDeviceAttributes={this.props.readDeviceAttributes}
+                            writeDeviceAttributes={this.props.writeDeviceAttributes}
+                        />
+                    </div>
                 </div>
                 <div className="card">
                     <div className="card-body">


### PR DESCRIPTION
Hello,

I would like to work a little on AttributeEditor, but I noticed that the code of the new feature - Definition Generator - is placed in the same component. This complicates the code a bit, so I moved AttributeEditor and DefinitionGenerator to new files. Now DevConsole does not contain any logic, it only points to existing components.