### PR TITLE
Check Enum length to avoid crashing, Issue #1895

### DIFF
--- a/src/components/features/enum/enum.tsx
+++ b/src/components/features/enum/enum.tsx
@@ -16,7 +16,7 @@ const Enum: FunctionComponent<EnumProps> = (props) => {
         minimal,
     } = props;
 
-    const thisIsVeryBigEnumeration = values.length > VERY_BIG_ENUM_SIZE;
+    const thisIsVeryBigEnumeration = values && values.length > VERY_BIG_ENUM_SIZE;
 
     if (access & FeatureAccessMode.ACCESS_WRITE) {
         return (


### PR DESCRIPTION
I found a bug as described [here](https://github.com/nurikk/zigbee2mqtt-frontend/issues/1895), I tracked it to this line and added a check to see if it was defined. 
Tested locally on my Z2M and it has fixed my issue.