### PR TITLE
feat(ui): display entity hint on mouse hover

### DIFF
--- a/src/components/features/composite/FeatureWrapper.tsx
+++ b/src/components/features/composite/FeatureWrapper.tsx
@@ -22,11 +22,14 @@ export const FeatureWrapper: FunctionComponent<PropsWithChildren<FeatureWrapperP
         label = `${parentFeature.label} ${feature.label.charAt(0).toLowerCase()}${feature.label.slice(1)}`;
     }
 
+    const {hint, ...featureWithoutHint } = feature;
+    const title = JSON.stringify(featureWithoutHint) + "\n\n" + hint;
+
     const leftColumn = (
         <div className="col-12 col-md-3">
             <label className="col-form-label w-100">
                 <div className="d-flex justify-content-between">
-                    <strong title={JSON.stringify(feature)}>{label}</strong>
+                    <strong title={title}>{label}</strong>
                     {isReadable ? (
                         <Button<CompositeFeature | GenericExposedFeature>
                             item={feature}

--- a/src/components/features/composite/FeatureWrapper.tsx
+++ b/src/components/features/composite/FeatureWrapper.tsx
@@ -23,7 +23,7 @@ export const FeatureWrapper: FunctionComponent<PropsWithChildren<FeatureWrapperP
     }
 
     const {hint, ...featureWithoutHint } = feature;
-    const title = JSON.stringify(featureWithoutHint) + "\n\n" + hint;
+    const title = JSON.stringify(featureWithoutHint) + (hint ? "\n\n" + hint : "");
 
     const leftColumn = (
         <div className="col-12 col-md-3">


### PR DESCRIPTION
Some devices may expose quite a lot of items. If these items are supplied with a description, the interface may get cluttered. If the description has certain amount of text describing values of the field, the interface gets too busy.

The idea of the proposed change is to have a hint field in addition to the description field in the device definition. The description may be used for a short 1-line description of the entity, while the hint may include big amount of text describing entity values or more detailed description of the setting. The hint text is not visible by default, but is shown in a hint/bubble when mouse is over the element.

![image](https://github.com/nurikk/zigbee2mqtt-frontend/assets/23584882/60d5ff9b-0006-4dad-a690-429a1b10ea43)

This is a UI part of the change, it comes with [this change](https://github.com/Koenkk/zigbee-herdsman-converters/pull/7012) in the herdsman converters, adding support for Hint field. Here is the usage:
```
    const relay_mode_description = "Mode of the internal relay switch";
    const relay_mode_hint = `The mode of the internal relay switch:
	unlinked - relay decoupled, button triggers only logical actions.
	front - relay toggles on initial press for immediate response.
	single - relay toggles on one press, generates 'single' action.
	double - relay toggles on two presses, generates 'double' action.
	triple - relay toggles on three presses, generates 'triple' action.
	long - relay toggles on press-and-hold, generates 'hold' action, and 'release' action upon button release`;
    sw.withFeature(e.enum('relay_mode', ea.ALL, relayModeValues)
        .withDescription(relay_mode_description)
        .withHint(relay_mode_hint));

```