### PR TITLE
fix(i18n): missing keys and hardcoded translation prompt

### DIFF
--- a/src/components/settings-page/index.tsx
+++ b/src/components/settings-page/index.tsx
@@ -168,10 +168,11 @@ export class SettingsPage extends Component<
         }
     }
     renderTranslate(): JSX.Element {
+        const { t } = this.props;
         return (
             <div className="p-3">
                 <p>
-                    You can help with the translation at{' '}
+                    {t('settings:translation_prompt')}{' '}
                     <a
                         target="_blank"
                         rel="noopener noreferrer"

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2602,7 +2602,8 @@
     "coordinator_ieee_address": "Coordinator IEEE Address",
     "request_z2m_backup": "Request Z2m backup",
     "add_install_code": "Add install code",
-    "homeassistant": "Home Assistant integration"
+    "homeassistant": "Home Assistant integration",
+    "translation_prompt": "You can help with the translation at"
   },
   "touchlink": {
     "detected_devices_message": "Detected {{count}} touchlink devices.",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2602,8 +2602,12 @@
     "coordinator_ieee_address": "Coordinator IEEE Address",
     "request_z2m_backup": "Request Z2m backup",
     "add_install_code": "Add install code",
+    "enter_install_code": "Enter install code",
     "homeassistant": "Home Assistant integration",
-    "translation_prompt": "You can help with the translation at"
+    "translation_prompt": "You can help with the translation at",
+    "zigbee_herdsman_converters_version": "zigbee-herdsman-converters version",
+    "zigbee_herdsman_version": "zigbee-herdsman version",
+    "localise_images": "Localise device images"
   },
   "touchlink": {
     "detected_devices_message": "Detected {{count}} touchlink devices.",


### PR DESCRIPTION
As was suggested [here](https://github.com/nurikk/zigbee2mqtt-frontend/pull/1898#issuecomment-1937862317), I'm creating this PR to add the following missing translation keys:
- `enter_install_code`
- `zigbee_herdsman_converters_version`
- `zigbee_herdsman_version`
- `localise_images`

Also I've added a `translation_prompt` translation key and necessary translation code for text, that suggests translation contributions. I think it was quite ironic to have it hardcoded in English.