### PR TITLE
Improve UX when renaming & describing a device

### DIFF
--- a/src/components/dashboard-page/DeviceFooter.tsx
+++ b/src/components/dashboard-page/DeviceFooter.tsx
@@ -1,4 +1,4 @@
-import PowerSource from '../../components/power-source';
+import PowerSource from '../power-source';
 import React from 'react';
 import { Device, DeviceState, LastSeenType } from '../../types';
 

--- a/src/components/device-control/DeviceControlEditName.tsx
+++ b/src/components/device-control/DeviceControlEditName.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import Button from '../button';
+import { Device } from '../../types';
+
+import { useTranslation } from 'react-i18next';
+import { RenameDeviceModal } from '../modal/components/RenameDeviceModal';
+import NiceModal from '@ebay/nice-modal-react';
+
+interface DeviceControlEditNameProps {
+    device: Device;
+    renameDevice(old: string, newName: string, homeassistantRename: boolean): Promise<void>;
+    homeassistantEnabled: boolean;
+}
+
+export const DeviceControlEditName = (props: DeviceControlEditNameProps): JSX.Element => {
+    const { homeassistantEnabled, device, renameDevice } = props;
+    const { t } = useTranslation(['zigbee', 'common']);
+
+    return (
+        <Button<void>
+            className="btn btn-primary btn btn-primary btn-sm d-none d-md-inline mx-1"
+            onClick={() =>
+                NiceModal.show(RenameDeviceModal, {
+                    device,
+                    renameDevice,
+                })
+            }
+            title={t('rename_device')}
+        >
+            <i className="fa fa-edit" />
+        </Button>
+    );
+}

--- a/src/components/device-control/DeviceControlEditName.tsx
+++ b/src/components/device-control/DeviceControlEditName.tsx
@@ -10,15 +10,16 @@ interface DeviceControlEditNameProps {
     device: Device;
     renameDevice(old: string, newName: string, homeassistantRename: boolean): Promise<void>;
     homeassistantEnabled: boolean;
+    style: 'link' | 'primary' | 'secondary' | 'success' | 'danger' | 'warning' | 'info' | 'light' | 'dark';
 }
 
 export const DeviceControlEditName = (props: DeviceControlEditNameProps): JSX.Element => {
-    const { homeassistantEnabled, device, renameDevice } = props;
+    const { homeassistantEnabled, device, renameDevice, style } = props;
     const { t } = useTranslation(['zigbee', 'common']);
 
     return (
         <Button<void>
-            className="btn btn-primary btn btn-primary btn-sm d-none d-md-inline mx-1"
+            className={`btn btn-${style} btn-sm d-none d-md-inline-block mx-1`}
             onClick={() =>
                 NiceModal.show(RenameDeviceModal, {
                     device,

--- a/src/components/device-control/DeviceControlEditName.tsx
+++ b/src/components/device-control/DeviceControlEditName.tsx
@@ -31,4 +31,4 @@ export const DeviceControlEditName = (props: DeviceControlEditNameProps): JSX.El
             <i className="fa fa-edit" />
         </Button>
     );
-}
+};

--- a/src/components/device-control/DeviceControlGroup.tsx
+++ b/src/components/device-control/DeviceControlGroup.tsx
@@ -29,6 +29,7 @@ export function DeviceControlGroup(
                 device={device}
                 renameDevice={props.renameDevice}
                 homeassistantEnabled={props.homeassistantEnabled}
+                style={'primary'}
             />
             <Button<string>
                 className="btn btn-warning"

--- a/src/components/device-control/DeviceControlGroup.tsx
+++ b/src/components/device-control/DeviceControlGroup.tsx
@@ -51,5 +51,4 @@ export function DeviceControlGroup(
     );
 }
 
-
 export default DeviceControlGroup;

--- a/src/components/device-control/DeviceControlGroup.tsx
+++ b/src/components/device-control/DeviceControlGroup.tsx
@@ -6,9 +6,9 @@ import { DeviceApi } from '../../actions/DeviceApi';
 import cx from 'classnames';
 
 import { useTranslation } from 'react-i18next';
-import { RenameDeviceModal } from '../modal/components/RenameDeviceModal';
 import NiceModal from '@ebay/nice-modal-react';
 import { RemoveDeviceModal } from '../modal/components/RemoveDeviceModal';
+import { DeviceControlEditName } from './DeviceControlEditName';
 
 interface DeviceControlGroupProps {
     device: Device;
@@ -20,25 +20,16 @@ export function DeviceControlGroup(
     props: DeviceControlGroupProps &
         Pick<DeviceApi, 'configureDevice' | 'renameDevice' | 'removeDevice' | 'setDeviceDescription'>,
 ): JSX.Element {
-    const { homeassistantEnabled, device, configureDevice, renameDevice, removeDevice, setDeviceDescription } = props;
+    const { device, configureDevice, removeDevice } = props;
     const { t } = useTranslation(['zigbee', 'common']);
 
     return (
         <div className="btn-group btn-group-sm" role="group">
-            <Button<void>
-                className="btn btn-primary"
-                onClick={() =>
-                    NiceModal.show(RenameDeviceModal, {
-                        device,
-                        renameDevice,
-                        setDeviceDescription,
-                        homeassistantEnabled,
-                    })
-                }
-                title={t('rename_device')}
-            >
-                <i className="fa fa-edit" />
-            </Button>
+            <DeviceControlEditName
+                device={device}
+                renameDevice={props.renameDevice}
+                homeassistantEnabled={props.homeassistantEnabled}
+            />
             <Button<string>
                 className="btn btn-warning"
                 onClick={configureDevice}
@@ -58,4 +49,6 @@ export function DeviceControlGroup(
         </div>
     );
 }
+
+
 export default DeviceControlGroup;

--- a/src/components/device-control/DeviceControlUpdateDesc.tsx
+++ b/src/components/device-control/DeviceControlUpdateDesc.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import Button from '../button';
+import { Device } from '../../types';
+
+import { useTranslation } from 'react-i18next';
+import NiceModal from '@ebay/nice-modal-react';
+import { UpdateDeviceDescModal } from '../modal/components/EditDeviceDescModal';
+
+interface DeviceControlUpdateDescProps {
+    device: Device;
+    setDeviceDescription(old: string, newDesc: string): Promise<void>;
+}
+
+export const DeviceControlUpdateDesc = (props: DeviceControlUpdateDescProps): JSX.Element => {
+    const { device, setDeviceDescription } = props;
+    const { t } = useTranslation(['zigbee', 'common']);
+
+    return (
+        <Button<void>
+            className="btn btn-primary btn btn-primary btn-sm d-none d-md-inline-block mx-1"
+            onClick={() =>
+                NiceModal.show(UpdateDeviceDescModal, {
+                    device,
+                    setDeviceDescription,
+                })
+            }
+            title={t('edit_description')}
+        >
+            <i className="fa fa-edit" />
+        </Button>
+    );
+}

--- a/src/components/device-control/DeviceControlUpdateDesc.tsx
+++ b/src/components/device-control/DeviceControlUpdateDesc.tsx
@@ -29,4 +29,4 @@ export const DeviceControlUpdateDesc = (props: DeviceControlUpdateDescProps): JS
             <i className="fa fa-edit" />
         </Button>
     );
-}
+};

--- a/src/components/device-control/DeviceControlUpdateDesc.tsx
+++ b/src/components/device-control/DeviceControlUpdateDesc.tsx
@@ -17,7 +17,7 @@ export const DeviceControlUpdateDesc = (props: DeviceControlUpdateDescProps): JS
 
     return (
         <Button<void>
-            className="btn btn-primary btn btn-primary btn-sm d-none d-md-inline-block mx-1"
+            className="btn btn-link btn-sm d-none d-md-inline-block mx-1"
             onClick={() =>
                 NiceModal.show(UpdateDeviceDescModal, {
                     device,

--- a/src/components/device-page/info.tsx
+++ b/src/components/device-page/info.tsx
@@ -80,7 +80,12 @@ export class DeviceInfo extends Component<
             },
             {
                 translationKey: 'avaliability:avaliability',
-                render: (device: Device, state: DeviceState, bridgeInfo: BridgeInfo, availability: AvailabilityState) => {
+                render: (
+                    device: Device,
+                    state: DeviceState,
+                    bridgeInfo: BridgeInfo,
+                    availability: AvailabilityState,
+                ) => {
                     const { config } = bridgeInfo;
                     const availabilityFeatureEnabled = !!config.availability;
                     const availabilityEnabledForDevice = config.devices[device.ieee_address]?.availability !== false;

--- a/src/components/device-page/info.tsx
+++ b/src/components/device-page/info.tsx
@@ -18,7 +18,8 @@ import { Availability } from '../zigbee/Availability';
 import { DeviceApi } from '../../actions/DeviceApi';
 import actions from '../../actions/actions';
 import { TFunction } from 'i18next';
-
+import { DeviceControlEditName } from '../device-control/DeviceControlEditName';
+import { DeviceControlUpdateDesc } from '../device-control/DeviceControlUpdateDesc';
 type DeviceInfoProps = {
     device: Device;
 };
@@ -27,168 +28,6 @@ type PropsFromStore = Pick<GlobalState, 'deviceStates' | 'bridgeInfo' | 'availab
 // [Flower sensor](https://modkam.ru/?p=1700)
 const markdownLinkRegex = /\[(.*?)]\((.*?)\)/;
 
-const displayProps = [
-    {
-        translationKey: 'friendly_name',
-        render: (device: Device) => (
-            <dd className="col-12 col-md-7">
-                <strong>{device.friendly_name}</strong>
-            </dd>
-        ),
-    },
-    {
-        translationKey: 'zigbee:description',
-        render: (device: Device) => (
-            <dd className="col-12 col-md-7">
-                <pre>{device.description}</pre>
-            </dd>
-        ),
-    },
-    {
-        translationKey: 'last_seen',
-        render: (device: Device, state: DeviceState, bridgeInfo: BridgeInfo) => (
-            <dd className="col-12 col-md-7">
-                <LastSeen lastSeenType={bridgeInfo.config.advanced.last_seen} state={state} />
-            </dd>
-        ),
-    },
-    {
-        translationKey: 'avaliability:avaliability',
-        render: (device: Device, state: DeviceState, bridgeInfo: BridgeInfo, availability: AvailabilityState) => {
-            const { config } = bridgeInfo;
-            const availabilityFeatureEnabled = !!config.availability;
-            const availabilityEnabledForDevice = config.devices[device.ieee_address]?.availability !== false;
-
-            return (
-                <dd className="col-12 col-md-7">
-                    <Availability
-                        availability={availability}
-                        disabled={isDeviceDisabled(device, config)}
-                        availabilityFeatureEnabled={availabilityFeatureEnabled}
-                        availabilityEnabledForDevice={availabilityEnabledForDevice}
-                    />
-                </dd>
-            );
-        },
-    },
-    {
-        key: 'type',
-        translationKey: 'device_type',
-    },
-    {
-        key: 'model_id',
-        translationKey: 'zigbee_model',
-    },
-    {
-        key: 'manufacturer',
-        translationKey: 'zigbee_manufacturer',
-    },
-    {
-        key: 'definition.description',
-        translationKey: 'description',
-        if: 'supported',
-        render: (device: Device) => {
-            const result = markdownLinkRegex.exec(device.definition?.description as string);
-            let content = <span>{device.definition?.description}</span>;
-            if (result) {
-                // eslint-disable-next-line @typescript-eslint/no-unused-vars
-                const [all, title, link] = result;
-                content = (
-                    <a target="_blank" rel="noopener noreferrer" href={link}>
-                        {title}
-                    </a>
-                );
-            }
-            return <dd className="col-12 col-md-7">{content}</dd>;
-        },
-    },
-    {
-        render: (
-            device: Device,
-            state: DeviceState,
-            bridgeInfo: BridgeInfo,
-            availability: AvailabilityState,
-            t: TFunction,
-        ) => (
-            <dd className="col-12 col-md-7">
-                <p
-                    className={cx('mb-0', 'font-weight-bold', {
-                        'text-danger': !device.supported,
-                        'text-success': device.supported,
-                    })}
-                >
-                    <DisplayValue name="supported" value={device.supported} />
-                    {!device.supported && (
-                        <>
-                            {' '}
-                            <a target="_blank" rel="noopener noreferrer" href={supportNewDevicesUrl}>
-                                ({t('how_to_add_support')})
-                            </a>
-                        </>
-                    )}
-                </p>
-            </dd>
-        ),
-        translationKey: 'support_status',
-    },
-    {
-        key: 'ieee_address',
-        translationKey: 'ieee_address',
-    },
-    {
-        key: 'network_address',
-        translationKey: 'network_address',
-        render: (device: Device) => <dd className="col-12 col-md-7">{toHex(device.network_address)}</dd>,
-    },
-    {
-        key: 'date_code',
-        translationKey: 'firmware_build_date',
-        if: 'date_code',
-    },
-    {
-        key: 'software_build_id',
-        translationKey: 'firmware_version',
-        if: 'software_build_id',
-    },
-
-    {
-        key: 'definition.vendor',
-        translationKey: 'manufacturer',
-        if: 'supported',
-        render: (device: Device) => (
-            <dd className="col-12 col-md-7">
-                <VendorLink device={device} />
-            </dd>
-        ),
-    },
-    {
-        key: 'definition.model',
-        translationKey: 'model',
-        if: 'supported',
-        render: (device: Device) => (
-            <dd className="col-12 col-md-7">
-                <ModelLink device={device} />
-            </dd>
-        ),
-    },
-
-    {
-        translationKey: 'power',
-        render: (device: Device, deviceStatus: DeviceState) => (
-            <dd className="col-12 col-md-7">
-                <PowerSource showLevel={true} device={device} deviceState={deviceStatus} />
-            </dd>
-        ),
-    },
-    {
-        translationKey: 'interview_completed',
-        render: (device: Device) => (
-            <dd className="col-12 col-md-7">
-                <DisplayValue name="interview_completed" value={device.interview_completed} />
-            </dd>
-        ),
-    },
-];
 // eslint-disable-next-line react/prefer-stateless-function
 export class DeviceInfo extends Component<
     Pick<DeviceApi, 'configureDevice' | 'renameDevice' | 'removeDevice' | 'setDeviceDescription'> &
@@ -202,6 +41,179 @@ export class DeviceInfo extends Component<
         const { configureDevice, renameDevice, removeDevice, setDeviceDescription } = this.props;
         const homeassistantEnabled = !!bridgeInfo.config?.homeassistant;
         const deviceState: DeviceState = deviceStates[device.friendly_name] ?? ({} as DeviceState);
+
+        const displayProps = [
+            {
+                translationKey: 'friendly_name',
+                render: (device: Device) => (
+                    <dd className="col-12 col-md-7">
+                        <strong>{device.friendly_name}</strong>
+                        <DeviceControlEditName
+                            device={device}
+                            renameDevice={renameDevice}
+                            homeassistantEnabled={homeassistantEnabled}
+                        />
+                    </dd>
+                ),
+            },
+            {
+                translationKey: 'zigbee:description',
+                render: (device: Device) => (
+                    <dd className="col-12 col-md-7">
+                        <pre style={{ display: 'inline' }}>{device.description}</pre>
+                        <DeviceControlUpdateDesc
+                            device={device}
+                            setDeviceDescription={setDeviceDescription}
+                        />
+                    </dd>
+                ),
+            },
+            {
+                translationKey: 'last_seen',
+                render: (device: Device, state: DeviceState, bridgeInfo: BridgeInfo) => (
+                    <dd className="col-12 col-md-7">
+                        <LastSeen lastSeenType={bridgeInfo.config.advanced.last_seen} state={state} />
+                    </dd>
+                ),
+            },
+            {
+                translationKey: 'avaliability:avaliability',
+                render: (device: Device, state: DeviceState, bridgeInfo: BridgeInfo, availability: AvailabilityState) => {
+                    const { config } = bridgeInfo;
+                    const availabilityFeatureEnabled = !!config.availability;
+                    const availabilityEnabledForDevice = config.devices[device.ieee_address]?.availability !== false;
+
+                    return (
+                        <dd className="col-12 col-md-7">
+                            <Availability
+                                availability={availability}
+                                disabled={isDeviceDisabled(device, config)}
+                                availabilityFeatureEnabled={availabilityFeatureEnabled}
+                                availabilityEnabledForDevice={availabilityEnabledForDevice}
+                            />
+                        </dd>
+                    );
+                },
+            },
+            {
+                key: 'type',
+                translationKey: 'device_type',
+            },
+            {
+                key: 'model_id',
+                translationKey: 'zigbee_model',
+            },
+            {
+                key: 'manufacturer',
+                translationKey: 'zigbee_manufacturer',
+            },
+            {
+                key: 'definition.description',
+                translationKey: 'description',
+                if: 'supported',
+                render: (device: Device) => {
+                    const result = markdownLinkRegex.exec(device.definition?.description as string);
+                    let content = <span>{device.definition?.description}</span>;
+                    if (result) {
+                        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                        const [all, title, link] = result;
+                        content = (
+                            <a target="_blank" rel="noopener noreferrer" href={link}>
+                                {title}
+                            </a>
+                        );
+                    }
+                    return <dd className="col-12 col-md-7">{content}</dd>;
+                },
+            },
+            {
+                render: (
+                    device: Device,
+                    state: DeviceState,
+                    bridgeInfo: BridgeInfo,
+                    availability: AvailabilityState,
+                    t: TFunction,
+                ) => (
+                    <dd className="col-12 col-md-7">
+                        <p
+                            className={cx('mb-0', 'font-weight-bold', {
+                                'text-danger': !device.supported,
+                                'text-success': device.supported,
+                            })}
+                        >
+                            <DisplayValue name="supported" value={device.supported} />
+                            {!device.supported && (
+                                <>
+                                    {' '}
+                                    <a target="_blank" rel="noopener noreferrer" href={supportNewDevicesUrl}>
+                                        ({t('how_to_add_support')})
+                                    </a>
+                                </>
+                            )}
+                        </p>
+                    </dd>
+                ),
+                translationKey: 'support_status',
+            },
+            {
+                key: 'ieee_address',
+                translationKey: 'ieee_address',
+            },
+            {
+                key: 'network_address',
+                translationKey: 'network_address',
+                render: (device: Device) => <dd className="col-12 col-md-7">{toHex(device.network_address)}</dd>,
+            },
+            {
+                key: 'date_code',
+                translationKey: 'firmware_build_date',
+                if: 'date_code',
+            },
+            {
+                key: 'software_build_id',
+                translationKey: 'firmware_version',
+                if: 'software_build_id',
+            },
+
+            {
+                key: 'definition.vendor',
+                translationKey: 'manufacturer',
+                if: 'supported',
+                render: (device: Device) => (
+                    <dd className="col-12 col-md-7">
+                        <VendorLink device={device} />
+                    </dd>
+                ),
+            },
+            {
+                key: 'definition.model',
+                translationKey: 'model',
+                if: 'supported',
+                render: (device: Device) => (
+                    <dd className="col-12 col-md-7">
+                        <ModelLink device={device} />
+                    </dd>
+                ),
+            },
+
+            {
+                translationKey: 'power',
+                render: (device: Device, deviceStatus: DeviceState) => (
+                    <dd className="col-12 col-md-7">
+                        <PowerSource showLevel={true} device={device} deviceState={deviceStatus} />
+                    </dd>
+                ),
+            },
+            {
+                translationKey: 'interview_completed',
+                render: (device: Device) => (
+                    <dd className="col-12 col-md-7">
+                        <DisplayValue name="interview_completed" value={device.interview_completed} />
+                    </dd>
+                ),
+            },
+        ];
+
         return (
             <Fragment>
                 <div className="d-flex justify-content-center">

--- a/src/components/device-page/info.tsx
+++ b/src/components/device-page/info.tsx
@@ -52,6 +52,7 @@ export class DeviceInfo extends Component<
                             device={device}
                             renameDevice={renameDevice}
                             homeassistantEnabled={homeassistantEnabled}
+                            style={'link'}
                         />
                     </dd>
                 ),
@@ -64,6 +65,7 @@ export class DeviceInfo extends Component<
                         <DeviceControlUpdateDesc
                             device={device}
                             setDeviceDescription={setDeviceDescription}
+                            style={'link'}
                         />
                     </dd>
                 ),

--- a/src/components/features/composite/Feature.tsx
+++ b/src/components/features/composite/Feature.tsx
@@ -20,7 +20,7 @@ import {
 import Binary from '../binary/binary';
 import Climate from '../climate/climate';
 import Cover from '../cover/cover';
-import Color from '../composite/color/color';
+import Color from './color/color';
 import Enum from '../enum/enum';
 import Light from '../light/light';
 import Lock from '../lock/lock';

--- a/src/components/modal/components/EditDeviceDescModal.tsx
+++ b/src/components/modal/components/EditDeviceDescModal.tsx
@@ -1,0 +1,61 @@
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { Device } from '../../../types';
+
+import NiceModal, { useModal } from '@ebay/nice-modal-react';
+
+import Modal, { ModalBody, ModalFooter, ModalHeader } from '../Modal';
+
+export type RenameActionProps = {
+    device: Device;
+    homeassistantEnabled: boolean;
+
+    renameDevice(old: string, newName: string, homeassistantRename: boolean): Promise<void>;
+    setDeviceDescription(friendly_name: string, description: string): Promise<void>;
+};
+export const UpdateDeviceDescModal = NiceModal.create((props: RenameActionProps): JSX.Element => {
+    const modal = useModal();
+    const { device, setDeviceDescription } = props;
+    const [description, setDescription] = useState(device.description);
+    const { t } = useTranslation(['zigbee', 'common']);
+
+    const onSaveDescriptionClick = async (): Promise<void> => {
+        await setDeviceDescription(device.friendly_name, description);
+        modal.remove();
+    };
+
+    return (
+        <Modal isOpen={modal.visible}>
+            <ModalHeader>
+                <h3>{t('update_description')}</h3>
+                <small>{device.friendly_name}</small>
+            </ModalHeader>
+            <ModalBody>
+                <div className="card">
+                        <div className="card-body">
+                            <div className="mb-3">
+                                <label className="form-label">{t('description')}</label>
+                                <textarea
+                                    rows={3}
+                                    onChange={(e) => setDescription(e.target.value)}
+                                    className="form-control"
+                                    value={description}
+                                />
+                            </div>
+                        </div>
+                        <div className="card-footer">
+                            <button type="button" className="btn btn-primary" onClick={onSaveDescriptionClick}>
+                                {t('zigbee:save_description')}
+                            </button>
+                        </div>
+                    </div>
+            </ModalBody>
+            <ModalFooter>
+                <button type="button" className="btn btn-secondary" onClick={modal.remove}>
+                    {t('common:close')}
+                </button>
+            </ModalFooter>
+        </Modal>
+    );
+});

--- a/src/components/modal/components/EditDeviceDescModal.tsx
+++ b/src/components/modal/components/EditDeviceDescModal.tsx
@@ -33,27 +33,25 @@ export const UpdateDeviceDescModal = NiceModal.create((props: RenameActionProps)
             </ModalHeader>
             <ModalBody>
                 <div className="card">
-                        <div className="card-body">
-                            <div className="mb-3">
-                                <label className="form-label">{t('description')}</label>
-                                <textarea
-                                    rows={3}
-                                    onChange={(e) => setDescription(e.target.value)}
-                                    className="form-control"
-                                    value={description}
-                                />
-                            </div>
-                        </div>
-                        <div className="card-footer">
-                            <button type="button" className="btn btn-primary" onClick={onSaveDescriptionClick}>
-                                {t('zigbee:save_description')}
-                            </button>
+                    <div className="card-body">
+                        <div className="mb-3">
+                            <label className="form-label">{t('description')}</label>
+                            <textarea
+                                rows={3}
+                                onChange={(e) => setDescription(e.target.value)}
+                                className="form-control"
+                                value={description}
+                            />
                         </div>
                     </div>
+                </div>
             </ModalBody>
             <ModalFooter>
                 <button type="button" className="btn btn-secondary" onClick={modal.remove}>
                     {t('common:close')}
+                </button>
+                <button type="button" className="btn btn-primary" onClick={onSaveDescriptionClick}>
+                    {t('zigbee:save_description')}
                 </button>
             </ModalFooter>
         </Modal>

--- a/src/components/modal/components/RenameDeviceModal.tsx
+++ b/src/components/modal/components/RenameDeviceModal.tsx
@@ -10,25 +10,17 @@ import Modal, { ModalBody, ModalFooter, ModalHeader } from '../Modal';
 export type RenameActionProps = {
     device: Device;
     homeassistantEnabled: boolean;
-
     renameDevice(old: string, newName: string, homeassistantRename: boolean): Promise<void>;
-    setDeviceDescription(friendly_name: string, description: string): Promise<void>;
 };
 export const RenameDeviceModal = NiceModal.create((props: RenameActionProps): JSX.Element => {
     const modal = useModal();
-    const { homeassistantEnabled, device, renameDevice, setDeviceDescription } = props;
+    const { homeassistantEnabled, device, renameDevice } = props;
     const [isHASSRename, setIsHASSRename] = useState(false);
     const [friendlyName, setFriendlyName] = useState(device.friendly_name);
-    const [description, setDescription] = useState(device.description);
     const { t } = useTranslation(['zigbee', 'common']);
 
     const onRenameClick = async (): Promise<void> => {
         await renameDevice(device.friendly_name, friendlyName, isHASSRename);
-        modal.remove();
-    };
-
-    const onSaveDescriptionClick = async (): Promise<void> => {
-        await setDeviceDescription(device.friendly_name, description);
         modal.remove();
     };
 
@@ -71,24 +63,7 @@ export const RenameDeviceModal = NiceModal.create((props: RenameActionProps): JS
                         </button>
                     </div>
                 </div>
-                <div className="card">
-                    <div className="card-body">
-                        <div className="mb-3">
-                            <label className="form-label">{t('description')}</label>
-                            <textarea
-                                rows={3}
-                                onChange={(e) => setDescription(e.target.value)}
-                                className="form-control"
-                                value={description}
-                            />
-                        </div>
-                    </div>
-                    <div className="card-footer">
-                        <button type="button" className="btn btn-primary" onClick={onSaveDescriptionClick}>
-                            {t('zigbee:save_description')}
-                        </button>
-                    </div>
-                </div>
+
             </ModalBody>
             <ModalFooter>
                 <button type="button" className="btn btn-secondary" onClick={modal.remove}>

--- a/src/components/modal/components/RenameDeviceModal.tsx
+++ b/src/components/modal/components/RenameDeviceModal.tsx
@@ -58,7 +58,6 @@ export const RenameDeviceModal = NiceModal.create((props: RenameActionProps): JS
                         ) : null}
                     </div>
                 </div>
-
             </ModalBody>
             <ModalFooter>
                 <button type="button" className="btn btn-secondary" onClick={modal.remove}>

--- a/src/components/modal/components/RenameDeviceModal.tsx
+++ b/src/components/modal/components/RenameDeviceModal.tsx
@@ -57,17 +57,15 @@ export const RenameDeviceModal = NiceModal.create((props: RenameActionProps): JS
                             </div>
                         ) : null}
                     </div>
-                    <div className="card-footer">
-                        <button type="button" className="btn btn-primary" onClick={onRenameClick}>
-                            {t('zigbee:rename_device')}
-                        </button>
-                    </div>
                 </div>
 
             </ModalBody>
             <ModalFooter>
                 <button type="button" className="btn btn-secondary" onClick={modal.remove}>
                     {t('common:close')}
+                </button>
+                <button type="button" className="btn btn-primary" onClick={onRenameClick}>
+                    {t('zigbee:rename_device')}
                 </button>
             </ModalFooter>
         </Modal>

--- a/src/components/settings-page/index.tsx
+++ b/src/components/settings-page/index.tsx
@@ -14,7 +14,7 @@ import { BridgeApi } from '../../actions/BridgeApi';
 import { WithTranslation, withTranslation } from 'react-i18next';
 import { DescriptionField, TitleField } from '../../i18n/rjsf-translation-fields';
 import { Stats } from './stats';
-import frontendPackageJson from '../../../package.json';
+import frontendPackageJson from '../../../../app/package.json';
 import { formatDate } from '../../utils';
 import { saveAs } from 'file-saver';
 import Spinner from '../spinner';

--- a/src/components/settings-page/index.tsx
+++ b/src/components/settings-page/index.tsx
@@ -14,7 +14,7 @@ import { BridgeApi } from '../../actions/BridgeApi';
 import { WithTranslation, withTranslation } from 'react-i18next';
 import { DescriptionField, TitleField } from '../../i18n/rjsf-translation-fields';
 import { Stats } from './stats';
-import frontendPackageJson from '../../../../app/package.json';
+import frontendPackageJson from './../../../package.json';
 import { formatDate } from '../../utils';
 import { saveAs } from 'file-saver';
 import Spinner from '../spinner';

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2683,7 +2683,8 @@
     "execute": "Execute",
     "command": "Command",
     "payload": "Payload",
-    "save_description": "Save description"
+    "save_description": "Save description",
+    "update_description": "Update description"
   },
   "scene": {
     "scene_id": "Scene ID",


### PR DESCRIPTION
Something that has bothered me is the lack of separation from updating a device name vs device description, so I've split them into 2 separate buttons, near the Device Info display


Before:
![image](https://github.com/nurikk/zigbee2mqtt-frontend/assets/655807/9b200a67-4358-43d7-81de-68e3ac007e87)


After:
![image](https://github.com/nurikk/zigbee2mqtt-frontend/assets/655807/000b2b3a-a696-41ae-86c0-39f4c6b35023)
![image](https://github.com/nurikk/zigbee2mqtt-frontend/assets/655807/3816e664-3ca9-4b4c-8899-683e75f6efe6)
![image](https://github.com/nurikk/zigbee2mqtt-frontend/assets/655807/70debc9f-a6fc-4989-bbe2-847365c58a3c)
