### PR TITLE
Make the device selector filter case insensitive + ignore the currently selected device

### DIFF
--- a/src/components/device-page/header-device-selector.test.tsx
+++ b/src/components/device-page/header-device-selector.test.tsx
@@ -15,7 +15,23 @@ it('all devices are visible in dropdown', async () => {
     };
     render(<HeaderDeviceSelector allDevices={devices} currentDevice={currentDevice} />);
     await waitFor(() => fireEvent.click(screen.getByLabelText(/Select a device/)));
-    expect(document.querySelectorAll('.dropdown-item')).toHaveLength(2);
+    expect(document.querySelectorAll('.dropdown-item')).toHaveLength(1);
+});
+
+it('the current device is excluded from the list', async () => {
+    const ieeeAddress1 = 'FF:FF:FF:FF:FF:AA';
+    const ieeeAddress2 = 'AA:AA:AA:AA:AA:AA';
+    const currentDevice = createMockDevice({ ieee_address: ieeeAddress1, friendly_name: 'DONT SHOW ME' });
+    const devices = {
+        [ieeeAddress1]: currentDevice,
+        [ieeeAddress2]: createMockDevice({ ieee_address: ieeeAddress2, friendly_name: 'Other Device' }),
+    };
+    render(<HeaderDeviceSelector allDevices={devices} currentDevice={currentDevice} />);
+    await waitFor(() => fireEvent.click(screen.getByLabelText(/Select a device/)));
+    expect(document.querySelectorAll('.dropdown-item'));
+
+    expect(document.querySelectorAll('.dropdown-item').item(0).textContent).toContain('Other Device');
+    expect(document.querySelectorAll('.dropdown-item').item(0).textContent).not.toContain('DONT SHOW ME');
 });
 
 it('device can be selected', async () => {

--- a/src/components/device-page/header-device-selector.tsx
+++ b/src/components/device-page/header-device-selector.tsx
@@ -25,10 +25,11 @@ export function HeaderDeviceSelectorRaw(props: HeaderDeviceSelectorProps): JSX.E
     const { allDevices, currentDevice, tab = 'info', t } = props;
     const [searchTerm, setSearchTerm] = useState<string>('');
 
-    const selectedDevices = Object.values(allDevices).filter((d) => (
-        d.friendly_name.toLowerCase().includes(searchTerm.toLowerCase()) &&
-        d.ieee_address !== currentDevice.ieee_address
-    ));
+    const selectedDevices = Object.values(allDevices).filter(
+        (d) =>
+            d.friendly_name.toLowerCase().includes(searchTerm.toLowerCase()) &&
+            d.ieee_address !== currentDevice.ieee_address,
+    );
 
     return (
         <h1 className="h3">

--- a/src/components/device-page/header-device-selector.tsx
+++ b/src/components/device-page/header-device-selector.tsx
@@ -25,7 +25,10 @@ export function HeaderDeviceSelectorRaw(props: HeaderDeviceSelectorProps): JSX.E
     const { allDevices, currentDevice, tab = 'info', t } = props;
     const [searchTerm, setSearchTerm] = useState<string>('');
 
-    const selectedDevices = Object.values(allDevices).filter((d) => d.friendly_name.includes(searchTerm));
+    const selectedDevices = Object.values(allDevices).filter((d) => (
+        d.friendly_name.toLowerCase().includes(searchTerm.toLowerCase()) &&
+        d.ieee_address !== currentDevice.ieee_address
+    ));
 
     return (
         <h1 className="h3">


### PR DESCRIPTION
@tigattack pointed out the filter is case insensitive
![image](https://github.com/nurikk/zigbee2mqtt-frontend/assets/655807/bf875716-a281-41ae-9166-ac0b2202200b)
![image](https://github.com/nurikk/zigbee2mqtt-frontend/assets/655807/37e93e56-149a-4790-b926-de95bfd5f20c)

So, I fixed it
![image](https://github.com/nurikk/zigbee2mqtt-frontend/assets/655807/602c5e1c-f2ee-482e-978a-0fe9747b30d5)

And added a little bonus to exclude the currently selected device
![Uploading image.png…]()