### PR TITLE
Improve Map loading screen

### DIFF
--- a/src/components/map/MapComponent.tsx
+++ b/src/components/map/MapComponent.tsx
@@ -129,9 +129,13 @@ export class MapComponent extends Component<PropsFromStore & MapApi & WithTransl
         return (
             <div className="h-100 d-flex justify-content-center align-items-center">
                 {networkGraphIsLoading ? (
-                    <div>
-                        <Spinner />
-                        <div>{t('loading')}</div>
+                    <div className="card">
+                        <div className="card-body">
+                            <div className="card-title">
+                                <Spinner />
+                            </div>
+                            <div>{t('loading')}</div>
+                        </div>
                     </div>
                 ) : (
                     <Button onClick={this.onRequestClick} className="btn btn-primary d-block">
@@ -214,11 +218,11 @@ export class MapComponent extends Component<PropsFromStore & MapApi & WithTransl
                 {networkGraph.nodes.length ? (
                     <Fragment>
                         {this.renderMapControls()} {this.renderMap()}
+                        {this.renderHelp()}
                     </Fragment>
                 ) : (
                     this.renderMessage()
                 )}
-                {this.renderHelp()}
             </div>
         );
     }

--- a/src/components/spinner.tsx
+++ b/src/components/spinner.tsx
@@ -2,9 +2,9 @@ import React, { FunctionComponent } from 'react';
 
 const Spinner: FunctionComponent = () => {
     return (
-        <div className="d-flex align-items-center">
-            <span>Loading, please wait.</span>
-            <div className="spinner-border me-2" />
+        <div className="d-flex align-items-center gap-2">
+            <span className="mr-2">Loading, please wait.</span>
+            <div className="spinner-border ml-2" />
         </div>
     );
 };


### PR DESCRIPTION
![image](https://github.com/nurikk/zigbee2mqtt-frontend/assets/655807/15d3dcbe-fe16-4e2b-b870-32c1d886ba86)

- Wrapped loading screen in a bootstrap card.
- Added gap to flex container for Loading spinner
- Hidden help area until map loaded
