### PR TITLE
feat(ScenePicker): show scene id when selecting a scene

### DIFF
--- a/src/components/device-page/ScenePicker.tsx
+++ b/src/components/device-page/ScenePicker.tsx
@@ -25,7 +25,7 @@ export function ScenePicker(props: ScenePickerProps): JSX.Element {
                 </option>
                 {scenes.map((scene) => (
                     <option key={`${scene.id}-${scene.endpoint}`} value={`${scene.id}-${scene.endpoint}`}>
-                        {scene.name}
+                       {scene.id}: {scene.name}
                     </option>
                 ))}
             </select>


### PR DESCRIPTION
When adding a scene, one is supposed to input the scene id.

Showing the IDs in the scene selector allows one to discover which IDs are already in use.

<img width="549" alt="Screenshot 2024-04-19 at 02 34 58" src="https://github.com/nurikk/zigbee2mqtt-frontend/assets/136261/7e937179-3e5c-4160-a1a5-ecaed41f770c">
