### PR TITLE
fix(dashboard): fix modernExtend entities not appearing on dashboard

### DIFF
--- a/src/components/dashboard-page/index.tsx
+++ b/src/components/dashboard-page/index.tsx
@@ -74,8 +74,7 @@ export const onlyValidFeaturesForDashboard = (
     if (genericRendererIgnoredNames.includes(name)) {
         return false;
     }
-
-    if (access & FeatureAccessMode.ACCESS_STATE && isOnlyOneBitIsSet(access)) {
+    if (access & FeatureAccessMode.ACCESS_STATE) {
         return filteredOutFeature;
     }
     if (Array.isArray(features) && features.length > 0) {


### PR DESCRIPTION
Fixes https://github.com/Koenkk/zigbee2mqtt/issues/21529

@nurikk do you have any clue why it checked on `isOnlyOneBitIsSet(access)`?