### PR TITLE
fix(ui): display toggle to rename Home Assistant entity ID

### DIFF
--- a/src/components/device-control/DeviceControlEditName.tsx
+++ b/src/components/device-control/DeviceControlEditName.tsx
@@ -24,6 +24,7 @@ export const DeviceControlEditName = (props: DeviceControlEditNameProps): JSX.El
                 NiceModal.show(RenameDeviceModal, {
                     device,
                     renameDevice,
+                    homeassistantEnabled,
                 })
             }
             title={t('rename_device')}


### PR DESCRIPTION
## Description

This PR fixes a regression that was introduced by https://github.com/nurikk/zigbee2mqtt-frontend/pull/1967, causing the "Update Home Assistant entity ID" toggle to not be displayed in the device rename modal.

## Related issues

Fixes: https://github.com/nurikk/zigbee2mqtt-frontend/issues/2008

## Before

![image](https://github.com/nurikk/zigbee2mqtt-frontend/assets/68558152/6b6ebe55-80b7-4437-a038-1ccf131cceeb)

## After

![image](https://github.com/nurikk/zigbee2mqtt-frontend/assets/68558152/634c84b9-b747-4aad-86b0-b25223b82152)
