### PR TITLE
feat(DeviceControlGroup): add interview button

### DIFF
--- a/src/actions/DeviceApi.ts
+++ b/src/actions/DeviceApi.ts
@@ -11,6 +11,7 @@ export interface DeviceApi {
     ): Promise<void>;
     removeDevice(dev: string, force: boolean, block: boolean): Promise<void>;
     configureDevice(name: string): Promise<void>;
+    interviewDevice(name: string): Promise<void>;
 
     setDeviceOptions(id: string, options: Record<string, unknown>): Promise<void>;
     setDeviceDescription(id: string, description: string): Promise<void>;
@@ -46,6 +47,10 @@ export default {
 
     configureDevice: (_state, name: string): Promise<void> => {
         return api.send("bridge/request/device/configure", { id: name });
+    },
+
+    interviewDevice: (_state, name: string): Promise<void> => {
+        return api.send("bridge/request/device/interview", { id: name });
     },
 
     setDeviceOptions: (_state, id: string, options: Record<string, unknown>): Promise<void> => {

--- a/src/components/device-control/DeviceControlGroup.tsx
+++ b/src/components/device-control/DeviceControlGroup.tsx
@@ -18,7 +18,10 @@ interface DeviceControlGroupProps {
 
 export function DeviceControlGroup(
     props: DeviceControlGroupProps &
-        Pick<DeviceApi, 'configureDevice' | 'renameDevice' | 'removeDevice' | 'setDeviceDescription' | 'interviewDevice'>,
+        Pick<
+            DeviceApi,
+            'configureDevice' | 'renameDevice' | 'removeDevice' | 'setDeviceDescription' | 'interviewDevice'
+        >,
 ): JSX.Element {
     const { device, configureDevice, removeDevice, interviewDevice } = props;
     const { t } = useTranslation(['zigbee', 'common']);

--- a/src/components/device-control/DeviceControlGroup.tsx
+++ b/src/components/device-control/DeviceControlGroup.tsx
@@ -18,9 +18,9 @@ interface DeviceControlGroupProps {
 
 export function DeviceControlGroup(
     props: DeviceControlGroupProps &
-        Pick<DeviceApi, 'configureDevice' | 'renameDevice' | 'removeDevice' | 'setDeviceDescription'>,
+        Pick<DeviceApi, 'configureDevice' | 'renameDevice' | 'removeDevice' | 'setDeviceDescription' | 'interviewDevice'>,
 ): JSX.Element {
-    const { device, configureDevice, removeDevice } = props;
+    const { device, configureDevice, removeDevice, interviewDevice } = props;
     const { t } = useTranslation(['zigbee', 'common']);
 
     return (
@@ -39,6 +39,15 @@ export function DeviceControlGroup(
                 prompt
             >
                 <i className={cx('fa', 'fa-retweet')} />
+            </Button>
+            <Button<string>
+                className="btn btn-info"
+                onClick={interviewDevice}
+                item={device.friendly_name}
+                title={t('interview')}
+                prompt
+            >
+                <i className={cx('fa', 'fa-info')} />
             </Button>
             <button
                 onClick={() => NiceModal.show(RemoveDeviceModal, { device, removeDevice })}

--- a/src/components/device-page/info.tsx
+++ b/src/components/device-page/info.tsx
@@ -30,7 +30,7 @@ const markdownLinkRegex = /\[(.*?)]\((.*?)\)/;
 
 // eslint-disable-next-line react/prefer-stateless-function
 export class DeviceInfo extends Component<
-    Pick<DeviceApi, 'configureDevice' | 'renameDevice' | 'removeDevice' | 'setDeviceDescription'> &
+    Pick<DeviceApi, 'configureDevice' | 'renameDevice' | 'removeDevice' | 'setDeviceDescription' | 'interviewDevice'> &
         DeviceInfoProps &
         PropsFromStore &
         WithTranslation<'zigbee'>,
@@ -38,7 +38,7 @@ export class DeviceInfo extends Component<
 > {
     render(): JSX.Element {
         const { device, deviceStates, bridgeInfo, availability, t } = this.props;
-        const { configureDevice, renameDevice, removeDevice, setDeviceDescription } = this.props;
+        const { configureDevice, renameDevice, removeDevice, setDeviceDescription, interviewDevice } = this.props;
         const homeassistantEnabled = !!bridgeInfo.config?.homeassistant;
         const deviceState: DeviceState = deviceStates[device.friendly_name] ?? ({} as DeviceState);
 
@@ -255,7 +255,7 @@ export class DeviceInfo extends Component<
                     device={device}
                     state={deviceState}
                     homeassistantEnabled={homeassistantEnabled}
-                    {...{ configureDevice, renameDevice, removeDevice, setDeviceDescription }}
+                    {...{ configureDevice, renameDevice, removeDevice, setDeviceDescription, interviewDevice }}
                 />
             </Fragment>
         );

--- a/src/components/zigbee/DevicesTable.tsx
+++ b/src/components/zigbee/DevicesTable.tsx
@@ -28,7 +28,10 @@ export type DevicesTableProps = {
 
 export function DevicesTable(
     props: DevicesTableProps &
-        Pick<DeviceApi, 'configureDevice' | 'renameDevice' | 'removeDevice' | 'setDeviceDescription' | 'interviewDevice'>,
+        Pick<
+            DeviceApi,
+            'configureDevice' | 'renameDevice' | 'removeDevice' | 'setDeviceDescription' | 'interviewDevice'
+        >,
 ): JSX.Element {
     const { data, lastSeenType, availabilityFeatureEnabled, homeassistantEnabled, setDeviceDescription } = props;
     const { renameDevice, removeDevice, configureDevice, interviewDevice } = props;
@@ -184,7 +187,16 @@ export function DevicesTable(
                 disableSortBy: true,
             },
         ],
-        [lastSeenCol, availabilityCol, t, homeassistantEnabled, renameDevice, removeDevice, configureDevice, interviewDevice],
+        [
+            lastSeenCol,
+            availabilityCol,
+            t,
+            homeassistantEnabled,
+            renameDevice,
+            removeDevice,
+            configureDevice,
+            interviewDevice,
+        ],
     );
 
     return (

--- a/src/components/zigbee/DevicesTable.tsx
+++ b/src/components/zigbee/DevicesTable.tsx
@@ -28,10 +28,10 @@ export type DevicesTableProps = {
 
 export function DevicesTable(
     props: DevicesTableProps &
-        Pick<DeviceApi, 'configureDevice' | 'renameDevice' | 'removeDevice' | 'setDeviceDescription'>,
+        Pick<DeviceApi, 'configureDevice' | 'renameDevice' | 'removeDevice' | 'setDeviceDescription' | 'interviewDevice'>,
 ): JSX.Element {
     const { data, lastSeenType, availabilityFeatureEnabled, homeassistantEnabled, setDeviceDescription } = props;
-    const { renameDevice, removeDevice, configureDevice } = props;
+    const { renameDevice, removeDevice, configureDevice, interviewDevice } = props;
 
     const { t } = useTranslation(['zigbee', 'common', 'avaliability']);
     const lastSeenCol =
@@ -177,14 +177,14 @@ export function DevicesTable(
                             device={device}
                             state={state}
                             homeassistantEnabled={homeassistantEnabled}
-                            {...{ renameDevice, removeDevice, configureDevice, setDeviceDescription }}
+                            {...{ renameDevice, removeDevice, configureDevice, setDeviceDescription, interviewDevice }}
                         />
                     );
                 },
                 disableSortBy: true,
             },
         ],
-        [lastSeenCol, availabilityCol, t, homeassistantEnabled, renameDevice, removeDevice, configureDevice],
+        [lastSeenCol, availabilityCol, t, homeassistantEnabled, renameDevice, removeDevice, configureDevice, interviewDevice],
     );
 
     return (

--- a/src/components/zigbee/index.tsx
+++ b/src/components/zigbee/index.tsx
@@ -19,7 +19,10 @@ export interface DevicesPageData {
 }
 
 type PropsFromStore = Pick<GlobalState, 'devices' | 'deviceStates' | 'bridgeInfo' | 'availability'>;
-type DevicesPageProps = Pick<DeviceApi, 'configureDevice' | 'renameDevice' | 'removeDevice' | 'setDeviceDescription' | 'interviewDevice'> &
+type DevicesPageProps = Pick<
+    DeviceApi,
+    'configureDevice' | 'renameDevice' | 'removeDevice' | 'setDeviceDescription' | 'interviewDevice'
+> &
     PropsFromStore &
     WithTranslation<'zigbee'>;
 

--- a/src/components/zigbee/index.tsx
+++ b/src/components/zigbee/index.tsx
@@ -19,7 +19,7 @@ export interface DevicesPageData {
 }
 
 type PropsFromStore = Pick<GlobalState, 'devices' | 'deviceStates' | 'bridgeInfo' | 'availability'>;
-type DevicesPageProps = Pick<DeviceApi, 'configureDevice' | 'renameDevice' | 'removeDevice' | 'setDeviceDescription'> &
+type DevicesPageProps = Pick<DeviceApi, 'configureDevice' | 'renameDevice' | 'removeDevice' | 'setDeviceDescription' | 'interviewDevice'> &
     PropsFromStore &
     WithTranslation<'zigbee'>;
 
@@ -30,7 +30,7 @@ function DevicesPage(props: DevicesPageProps): JSX.Element {
         bridgeInfo: { config },
         availability,
     } = props;
-    const { renameDevice, removeDevice, configureDevice, setDeviceDescription } = props;
+    const { renameDevice, removeDevice, configureDevice, setDeviceDescription, interviewDevice } = props;
     const availabilityFeatureEnabled = !!config.availability;
     const homeassistantEnabled = !!config?.homeassistant;
     const getDevicesToRender = (): DevicesPageData[] => {
@@ -56,7 +56,7 @@ function DevicesPage(props: DevicesPageProps): JSX.Element {
             lastSeenType={config.advanced.last_seen}
             availabilityFeatureEnabled={availabilityFeatureEnabled}
             homeassistantEnabled={homeassistantEnabled}
-            {...{ renameDevice, removeDevice, configureDevice, setDeviceDescription }}
+            {...{ renameDevice, removeDevice, configureDevice, setDeviceDescription, interviewDevice }}
         />
     );
 }


### PR DESCRIPTION
* Adds an "interview" button which starts an interview for the associated device. See https://github.com/Koenkk/zigbee2mqtt/pull/22788
* The icon is [fa-info](https://fontawesome.com/v6/icons/info?f=classic&s=solid).