### PR TITLE
fix(translation): ignore `en` translation from poeditor

### DIFF
--- a/download_translations.js
+++ b/download_translations.js
@@ -12,8 +12,12 @@ async function main(project_id, api_token) {
 
     for (const locale of locales) {
         const exported = await downloadLanguage(project_id, api_token, locale);
-        const fileName = locale2fileMap[locale.code] || locale.code;
-        await fs.writeFile(`./src/i18n/locales/${fileName}.json`, JSON.stringify(exported, null, 2));
+        const code = locale2fileMap[locale.code] || locale.code;
+        if (code === 'en') {
+            console.log('Ignoring `en` translation');
+        } else {
+            await fs.writeFile(`./src/i18n/locales/${code}.json`, JSON.stringify(exported, null, 2));
+        }
     }
 }
 


### PR DESCRIPTION
This PR updates `download_translation` to ignore the English translation from poeditor, instead the `en.json` from this repo will be used. This fixes some issues were empty text was showing up on the frontend because poeditor wasn't updated or translations were missing.

CC: @Nerivec 