### PR TITLE
feat(ui): display exact timestamp in the last seen device list field

### DIFF
--- a/src/components/LastSeen.tsx
+++ b/src/components/LastSeen.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { DeviceState, LastSeenType } from '../types';
 import { format } from 'timeago.js';
-import { lastSeen } from '../utils';
+import { lastSeen, formatDate } from '../utils';
 
 import { useTranslation } from 'react-i18next';
 
@@ -14,7 +14,7 @@ export function LastSeen(props: LastSeenProps): JSX.Element {
     const { state, lastSeenType } = props;
     const lastSeenDate = lastSeen(state, lastSeenType);
     if (lastSeenDate) {
-        return <>{format(lastSeenDate, i18n.language)}</>;
+        return <span title={formatDate(lastSeenDate)}>{format(lastSeenDate, i18n.language)}</span>;
     } else {
         return <>N/A</>;
     }


### PR DESCRIPTION
This pull request updates the "Last Seen" field in the device list and device card in dashboard. Previously, the field only showed relative time (e.g., "1 day ago"). I've added a title attribute to this field to display the exact date and time when you hover over it. This change helps users see the precise timestamp when needed, without losing the convenience of the relative time format.

<img width="275" alt="Screenshot 2024-10-10 at 17 54 34" src="https://github.com/user-attachments/assets/3bc688cc-3b25-44c4-92e8-43c4c7926c1b">
