### PR TITLE
Revert "fix: match 2.0.0 permit join API"

### DIFF
--- a/src/actions/BridgeApi.ts
+++ b/src/actions/BridgeApi.ts
@@ -3,7 +3,7 @@ import { Device } from '../types';
 import store from '../store';
 
 export interface BridgeApi {
-    setPermitJoin(time: number, device: Device): Promise<void>;
+    setPermitJoin(permit: boolean, device: Device): Promise<void>;
     updateBridgeConfig(options: unknown): Promise<void>;
     restartBridge(): Promise<void>;
     requestBackup(): Promise<void>;
@@ -11,8 +11,8 @@ export interface BridgeApi {
 }
 
 
-const setPermitJoin = (_state, time = 254, device?: Device): Promise<void> => {
-    return api.send("bridge/request/permit_join", { time, device: device?.friendly_name });
+const setPermitJoin = (_state, permit = true, device?: Device, time = 254): Promise<void> => {
+    return api.send("bridge/request/permit_join", { value: permit, time, device: device?.friendly_name });
 }
 
 export default {
@@ -29,6 +29,6 @@ export default {
     },
     async addInstallCode(_state, installCode: string): Promise<void> {
         await api.send('bridge/request/install_code/add', { value: installCode });
-        return setPermitJoin(_state, 254)
+        return setPermitJoin(_state, true)
     }
 }

--- a/src/components/navbar/StartStopJoinButton.tsx
+++ b/src/components/navbar/StartStopJoinButton.tsx
@@ -14,8 +14,7 @@ export function StartStopJoinButton({ devices, setPermitJoin, bridgeInfo }: Star
     const { t } = useTranslation(['navbar']);
     const { ref, isComponentVisible, setIsComponentVisible } = useComponentVisible(false);
     const [selectedRouter, setSelectedRouter] = useState<Device>({} as Device);
-    const { permit_join_timeout: permitJoinTimeout } = bridgeInfo;
-    const permitJoin = permitJoinTimeout > 0;
+    const { permit_join: permitJoin, permit_join_timeout: permitJoinTimeout } = bridgeInfo;
 
     const selectAndHide = (device: Device) => {
         setSelectedRouter(device);
@@ -37,7 +36,7 @@ export function StartStopJoinButton({ devices, setPermitJoin, bridgeInfo }: Star
         ));
 
     const onBtnClick = () => {
-        setPermitJoin(permitJoin ? 0 : 254, selectedRouter);
+        setPermitJoin(!permitJoin, selectedRouter);
     };
     const permitJoinTimer = (
         <>

--- a/src/types.ts
+++ b/src/types.ts
@@ -100,11 +100,14 @@ export interface BridgeConfig {
     coordinator: Coordinator;
     network: Network;
     log_level: string;
+    permit_join: boolean;
+
 }
 export type BridgeState = "online" | "offline";
 export interface BridgeInfo {
     config: Z2MConfig;
     config_schema: JSONSchema7;
+    permit_join: boolean;
     permit_join_timeout: number;
     commit?: string;
     version?: string;


### PR DESCRIPTION
Reverts nurikk/zigbee2mqtt-frontend#2158 since it only should be released with Z2M 2.0.0

Kept it in the https://github.com/nurikk/zigbee2mqtt-frontend/tree/feat/2.0.0 branch 

CC: @nurikk @Nerivec 