### PR TITLE
fix: consistent rep interval capitalization

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2668,7 +2668,7 @@
     "lqi": "LQI",
     "mains_single_phase": "Mains (single phase)",
     "manufacturer": "Manufacturer",
-    "max_rep_interval": "max rep interval",
+    "max_rep_interval": "Max rep interval",
     "min_rep_change": "Min rep change",
     "min_rep_interval": "Min rep interval",
     "model": "Model",


### PR DESCRIPTION
In the English localization, the capitalization of "max rep interval" is inconsistent with other column names, which are capitalized. See screenshot:

![image](https://github.com/user-attachments/assets/f11ef5a1-231a-4d35-9609-21665c573863)

This PR capitalizes the "M".

There were other capitalizations in the en.json file that looked suspect, but I didn't change any as I haven't observed them as inconsistent in the UI itself.

On a side note: It took me a sec to realize "rep" stood for reporting. Would it make sense to add a tooltip to get a description without an abbreviation?