### PR TITLE
feat(ui): show source routes on device pages

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2699,7 +2699,9 @@
     "command": "Command",
     "payload": "Payload",
     "save_description": "Save description",
-    "update_description": "Update description"
+    "update_description": "Update description",
+    "source_route": "Source route",
+    "direct_to_coordinator": "Direct to coordinator"
   },
   "scene": {
     "manage_scenes_header": "Manage scenes",

--- a/src/types.ts
+++ b/src/types.ts
@@ -271,6 +271,7 @@ export interface Device extends WithFriendlyName, WithDescription {
     ieee_address: IEEEEAddress;
     type: DeviceType;
     network_address: number;
+    source_route: number[];
     power_source?: PowerSource;
     model_id: string;
     manufacturer: string;


### PR DESCRIPTION
This adds source routes to device pages, and requires two upstream PRs first, so I'm marking this as draft.

https://github.com/Koenkk/zigbee2mqtt/pull/25205
https://github.com/Koenkk/zigbee-herdsman/pull/1264

The goal of https://github.com/Koenkk/zigbee2mqtt/issues/21859 is to help users debug offline devices. Sometimes, it's not the "offline" device itself but the device it's supposed to be routing through. For example, this shows that this button is routing through the device named "Plug".

<img width="1012" alt="image" src="https://github.com/user-attachments/assets/5d6f9534-6529-4772-a803-5669e611a118" />

Here's a better screenshot from my production network showing two relays:

<img width="1222" alt="image" src="https://github.com/user-attachments/assets/839655a9-4164-4d28-93e8-5d2c1af04db7" />
