### PR TITLE
feat(ui): Frontend notification blocklist

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -17,7 +17,7 @@ import { Theme } from './components/theme-switcher';
 import initialState from './initialState.json';
 
 export interface LogMessage {
-    level: "error" | "info" | "warning";
+    level: "error" | "info" | "warning" | "debug";
     message: string;
     timestamp: Date;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -86,6 +86,9 @@ export interface AdvancedConfig {
     last_seen: 'disable' | 'ISO_8601' | 'ISO_8601_local' | 'epoch';
     legacy_api: boolean;
 }
+export interface FrontendConfig {
+    notification_filter?: string[];
+}
 export interface Z2MConfig {
     homeassistant?: {
         enabled: boolean;
@@ -96,6 +99,7 @@ export interface Z2MConfig {
     advanced: AdvancedConfig;
     devices: Record<string, DeviceConfig>;
     device_options: DeviceConfig;
+    frontend: FrontendConfig;
     [k: string]: unknown;
 }
 export type BridgeState = 'online' | 'offline';

--- a/src/ws-client.ts
+++ b/src/ws-client.ts
@@ -27,27 +27,17 @@ interface Message {
     payload: string | Record<string, unknown> | Record<string, unknown>[] | string[];
 }
 
-const blacklistedMessages: RegExp[] = [
-    /MQTT publish/
+const blacklistedMessages: string[] = [
+    'MQTT publish'
 ];
 
-const isLogMessage = (msg: LogMessage | ResponseWithStatus): msg is LogMessage => {
-    return (msg as LogMessage).level !== undefined && (msg as LogMessage).message !== undefined;
-}
+const showNotify = (level: string, message: string, filter: boolean): void => {
+    if (filter) {
+        const { bridgeInfo } = store.getState();
+        const notificationFilter = blacklistedMessages.concat(bridgeInfo?.config?.frontend?.notification_filter ?? []);
 
-const isResponseWithStatus = (msg: LogMessage | ResponseWithStatus): msg is ResponseWithStatus => {
-    return (msg as ResponseWithStatus).status !== undefined;
-}
-
-const showNotify = (data: LogMessage | ResponseWithStatus): void => {
-    let message = "", level = "";
-    if (isLogMessage(data)) {
-        message = data.message;
-        level = data.level;
-    } else if (isResponseWithStatus(data)) {
-        if (data.status === "error") {
-            level = "error";
-            message = data.error as string;
+        if (notificationFilter.some((val) => (new RegExp(val)).test(message))) {
+            return;
         }
     }
 
@@ -197,8 +187,8 @@ class Api {
                     newLogs.push({ ...(data.payload as unknown as LogMessage), timestamp: new Date() } as LogMessage);
                     store.setState({ logs: newLogs });
                     const log = data.payload as unknown as LogMessage;
-                    if (blacklistedMessages.every(val => !val.test(log.message))) {
-                        showNotify(log);
+                    if (log.level !== 'debug') {
+                        showNotify(log.level, log.message, true);
                     }
                 }
                 break;
@@ -253,8 +243,11 @@ class Api {
                 break;
         }
         if (data.topic.startsWith("bridge/response/")) {
-            showNotify(data.payload as unknown as ResponseWithStatus);
-            this.resolvePromises(data.payload as unknown as ResponseWithStatus);
+            const log = data.payload as unknown as ResponseWithStatus;
+            if (log.status === "error") {
+                showNotify(log.status, log.error ?? "Unknown error", false);
+            }
+            this.resolvePromises(log);
         }
     }
 


### PR DESCRIPTION
This PR is a request to add a `notification_filter` node to frontend config that accepts an array of regex strings and hides matching toast notifications.

In large Zigbee networks with devices that are not always online, but not offline long enough to warrant using the `disabled` device setting and lose availability, it is very useful to be able to silence 'Failed to ping' toast notifications in the frontend UI. These are even more intrusive when using the frontend from a small screen device.

Instead of limiting the feature to only failed pings, this PR broadens the scope to allow the user to specify which messages don't result in a toast notification.

Schema: https://github.com/Koenkk/zigbee2mqtt/pull/26805
Documentation: https://github.com/Koenkk/zigbee2mqtt.io/pull/3617