### PR TITLE
fix: reconnect instead of reloading page on auth error

### DIFF
--- a/src/ws-client.ts
+++ b/src/ws-client.ts
@@ -286,7 +286,7 @@ class Api {
             local.remove(TOKEN_LOCAL_STORAGE_ITEM_NAME);
             showNotify('error', "Unauthorized", false);
             setTimeout(() => {
-                window.location.reload();
+                this.connect();
             }, 1000);
         }
     }


### PR DESCRIPTION
Small optimisation to auth.

Instead of waiting 1 second and reloading the entire page, trigger reconnection which will bring up auth modal.