### PR TITLE
feat: add a warning icon to OTA page for battery devices when battery is too low to safely run an update

### DIFF
--- a/src/components/ota-page/index.tsx
+++ b/src/components/ota-page/index.tsx
@@ -13,6 +13,7 @@ import { ModelLink, OTALink, VendorLink } from '../vendor-links/vendor-links';
 import { useTranslation, WithTranslation, withTranslation } from 'react-i18next';
 import { Column } from 'react-table';
 import { Table } from '../grid/ReactTableCom';
+import PowerSourceOTA from '../power-source/powerSourceOTA';
 import cx from 'classnames';
 
 type OtaRowProps = {
@@ -59,6 +60,7 @@ const StateCell: FunctionComponent<OtaRowProps & OtaApi> = (props) => {
                     >
                         <i className={cx('fa', 'fa-clock')} />
                     </Button>
+                    <PowerSourceOTA device={device} deviceState={state} />
                 </div>
             );
         case 'scheduled':

--- a/src/components/power-source/powerSourceOTA.tsx
+++ b/src/components/power-source/powerSourceOTA.tsx
@@ -2,7 +2,6 @@ import React, { Fragment, FunctionComponent } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Device, DeviceState } from '../../types';
 import style from './style.module.css';
-import { powerSourceTypeToTranslationKey } from './powerSourceTypeToTranslationKey';
 import type { PowerSource } from '../../types';
 
 interface PowerSourceOTAProps {
@@ -46,7 +45,7 @@ const PowerSourceOTA: FunctionComponent<PowerSourceOTAProps> = ({ device, device
     ) {
         return (
             <Fragment>
-                <i title={t('ota:battery_low_upd')} className="fa fa-circle-exclamation text-danger ms-2" />
+                <i title={t('ota:battery_low_upd')} className="fa fa-triangle-exclamation text-warning ms-2" />
             </Fragment>
         );
     }

--- a/src/components/power-source/powerSourceOTA.tsx
+++ b/src/components/power-source/powerSourceOTA.tsx
@@ -39,15 +39,14 @@ const PowerSourceOTA: FunctionComponent<PowerSourceOTAProps> = ({ device, device
     }
 
     // Some devices do not use the standardized feature `battery` to report power level.
-    if ((batteryPercent !== undefined && batteryPercent <= 50) ||
+    if (
+        (batteryPercent !== undefined && batteryPercent <= 50) ||
         (batteryState !== undefined && batteryState === 'low') ||
-        (batteryLow !== undefined && batteryLow === true)) {
+        (batteryLow !== undefined && batteryLow === true)
+    ) {
         return (
             <Fragment>
-                <i
-                    title={t('ota:battery_low_upd')}
-                    className="fa fa-circle-exclamation text-danger ms-2"
-                />
+                <i title={t('ota:battery_low_upd')} className="fa fa-circle-exclamation text-danger ms-2" />
             </Fragment>
         );
     }

--- a/src/components/power-source/powerSourceOTA.tsx
+++ b/src/components/power-source/powerSourceOTA.tsx
@@ -1,0 +1,56 @@
+import React, { Fragment, FunctionComponent } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Device, DeviceState } from '../../types';
+import style from './style.module.css';
+import { powerSourceTypeToTranslationKey } from './powerSourceTypeToTranslationKey';
+import type { PowerSource } from '../../types';
+
+interface PowerSourceOTAProps {
+    device?: Device;
+    deviceState?: DeviceState;
+}
+
+const PowerSourceOTA: FunctionComponent<PowerSourceOTAProps> = ({ device, deviceState, ...rest }) => {
+    const { t } = useTranslation('ota');
+    let source: PowerSource | undefined = undefined;
+
+    if (device !== undefined) {
+        source = device.power_source;
+    }
+
+    if (source !== 'Battery') {
+        return null;
+    }
+
+    let batteryPercent: number | undefined = undefined;
+    let batteryState: string | undefined = undefined;
+    let batteryLow: boolean | undefined = undefined;
+
+    if (deviceState !== undefined) {
+        if (deviceState?.battery !== undefined) {
+            batteryPercent = deviceState.battery as number;
+        }
+        if (deviceState?.battery_state !== undefined) {
+            batteryState = deviceState.battery_state as string;
+        }
+        if (deviceState?.battery_low !== undefined) {
+            batteryLow = deviceState.battery_low as boolean;
+        }
+    }
+
+    // Some devices do not use the standardized feature `battery` to report power level.
+    if ((batteryPercent !== undefined && batteryPercent <= 50) ||
+        (batteryState !== undefined && batteryState === 'low') ||
+        (batteryLow !== undefined && batteryLow === true)) {
+        return (
+            <Fragment>
+                <i
+                    title={t('ota:battery_low_upd')}
+                    className="fa fa-circle-exclamation text-danger ms-2"
+                />
+            </Fragment>
+        );
+    }
+};
+
+export default PowerSourceOTA;

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2577,6 +2577,7 @@
     "touchlink": "Touchlink"
   },
   "ota": {
+    "battery_low_upd": "The firmware update may fail if the batteries are not replaced",
     "check": "Check for new updates",
     "check_all": "Check all",
     "empty_ota_message": "You don't have any devices that support OTA",

--- a/ws-messages/onConnect.json
+++ b/ws-messages/onConnect.json
@@ -1407,7 +1407,7 @@
                 },
                 "friendly_name": "0xbc33acfffe17628b",
                 "ieee_address": "0xbc33acfffe17628b",
-                "interview_state": "FAILED",
+                "interview_state": "SUCCESSFUL",
                 "manufacturer": "IKEA of Sweden",
                 "model_id": "TRADFRI on/off switch",
                 "network_address": 25249,
@@ -2010,7 +2010,7 @@
                             "value_on": true
                         }
                     ],
-                    "supports_ota": false,
+                    "supports_ota": true,
                     "vendor": "Xiaomi"
                 },
                 "endpoints": {
@@ -2327,7 +2327,7 @@
                             "type": "numeric"
                         }
                     ],
-                    "supports_ota": false,
+                    "supports_ota": true,
                     "vendor": "Xiaomi"
                 },
                 "endpoints": {
@@ -2596,7 +2596,7 @@
                             "type": "numeric"
                         }
                     ],
-                    "supports_ota": false,
+                    "supports_ota": true,
                     "vendor": "Xiaomi"
                 },
                 "endpoints": {
@@ -8652,7 +8652,7 @@
         "topic": "bridge/extensions"
     },
     {
-        "payload": "offline",
+        "payload": "online",
         "topic": "0xbc33acfffe17628b/availability"
     },
     {
@@ -8707,7 +8707,13 @@
     },
     {
         "payload": {
-            "last_seen": "2022-04-15T16:33:53+08:00"
+	    "battery": 45,
+            "last_seen": "2022-04-15T16:33:53+08:00",
+            "update": {
+                "installed_version": 65552,
+                "latest_version": 16777233,
+                "state": "available"
+	    }
         },
         "topic": "0xbc33acfffe17628b"
     },
@@ -8748,7 +8754,12 @@
             "battery": 100,
             "last_seen": "2022-05-16T20:46:44+08:00",
             "linkquality": 66,
-            "voltage": 3042
+            "voltage": 3042,
+            "update": {
+                "installed_version": 65552,
+                "latest_version": 16777233,
+                "state": "available"
+            }
         },
         "topic": "0x00158d000224154d"
     },
@@ -8780,12 +8791,17 @@
     },
     {
         "payload": {
-            "battery": 100,
+            "battery": 65,
             "humidity": 65.59,
             "last_seen": "2022-05-16T20:37:54+08:00",
             "linkquality": 90,
             "temperature": 25.84,
-            "voltage": 3035
+            "voltage": 3035,
+            "update": {
+                "installed_version": 65552,
+                "latest_version": 16777233,
+                "state": "available"
+            }
         },
         "topic": "livingroom/temp_humidity"
     },
@@ -8811,13 +8827,19 @@
     },
     {
         "payload": {
-            "battery": 0,
+            "battery": 5,
             "humidity": 59.96,
             "last_seen": "2022-05-16T21:06:04+08:00",
+            "state": "ON",
             "linkquality": 12,
             "pressure": 1009.8,
             "temperature": 32.9,
-            "voltage": 2815
+            "voltage": 2815,
+            "update": {
+                "installed_version": 65552,
+                "latest_version": 16777233,
+                "state": "available"
+            }
         },
         "topic": "0x00158d0004866f11"
     },


### PR DESCRIPTION
If the battery of a battery powered device is too low to safely complete a firmware update there's no information on the OTA page.
I've got this same situation with my devices and I did not notice that battery was too low because I went straight to the OTA page.
See my conversation with @Nerivec in [#27098](https://github.com/Koenkk/zigbee2mqtt/issues/27098#top).

The icon is shown only when the battery is < 50% or is low or is battery_low.
I wanted to keep the code as much clean as possible so I have implemented a PowerSourceOTA that renders the danger icon.
The icon is not a red battery icon but a red circle with exclamation mark because I did not want to confuse the user with a red battery icon in this page when, for example at 49%, the icon in the device-page is dark grey indicating normal status of the battery.
Hoovering with the mouse over the icon shows a clear explanation message.
I have called the icon rendering at the end of the device line in the OTA page only if :

- the device is a battery device
- the above conditions are met
- a firmware update is available for that device

In all other conditions the icon is not rendered.

The example page looks like this:

![immagine](https://github.com/user-attachments/assets/66ca7e4b-2c2d-48de-ac94-aecf9bc2eb9d)

@Nerivec @Koenkk @nurikk please review and comment what can be done better or requires more attention on my side.