### PR TITLE
Add missing label for backup download button

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2617,6 +2617,7 @@
     "stats": "Stats",
     "coordinator_ieee_address": "Coordinator IEEE Address",
     "request_z2m_backup": "Request Z2m backup",
+    "download_z2m_backup": "Download Z2m backup",
     "add_install_code": "Add install code",
     "enter_install_code": "Enter install code",
     "homeassistant": "Home Assistant integration",


### PR DESCRIPTION
Button `download_z2m_backup` was missing its translation

![missing_translation](https://github.com/user-attachments/assets/e7dabf76-cc0c-4569-ba07-8d83704dce9d)
![fixed_translation](https://github.com/user-attachments/assets/07020874-7101-44d9-b8de-bc8a329cec4f)
