### PR TITLE
Omit the description field from schema to hide it from UI

### DIFF
--- a/src/components/logs-page/log-level-config.module.css
+++ b/src/components/logs-page/log-level-config.module.css
@@ -1,3 +1,0 @@
-.hide-description :global(.field-description) {
-    display: none;
-}

--- a/src/components/logs-page/log-level-config.module.css.d.ts
+++ b/src/components/logs-page/log-level-config.module.css.d.ts
@@ -1,5 +1,0 @@
-declare const classNames: {
-    readonly 'hide-description': 'hide-description';
-    readonly 'field-description': 'field-description';
-};
-export = classNames;

--- a/src/components/logs-page/log-level-config.tsx
+++ b/src/components/logs-page/log-level-config.tsx
@@ -6,7 +6,7 @@ import { JSONSchema7 } from 'json-schema';
 import { KVP, Z2MConfig } from '../../types';
 import get from 'lodash/get';
 import set from 'lodash/set';
-import styles from './log-level-config.module.css';
+import omit from 'lodash/omit'
 
 const Form = withTheme(Bootstrap5Theme);
 
@@ -21,14 +21,14 @@ type ConfigureLogsProps = {
 export default function ConfigureLogs(props: ConfigureLogsProps): JSX.Element {
     const { schema = {}, schemaKey = '', config = {}, configKey = '', onChange } = props;
     const formData = get(config, configKey, {});
-    const _schema = get(schema, schemaKey, {});
+    const _schema = omit(get(schema, schemaKey, {}), ['description']);
     const handleChange = (params: ISubmitEvent<KVP | KVP[]>) => {
         const payload = {};
         set(payload, configKey, params.formData);
         onChange(payload);
     };
     return (
-        <Form schema={_schema} className={styles['hide-description']} formData={formData} onChange={handleChange}>
+        <Form schema={_schema} formData={formData} onChange={handleChange}>
             <div />
         </Form>
     );


### PR DESCRIPTION
I spotted the issue with a redundant log level field description on the `/logs` page. 
It seems like it was solved by adding that `.hide-description` class, which doesn't work, perhaps because of `rjsf` newer version. 
Changed the solution so it won't be dependent on a class structure

Before
<img width="1470" height="458" alt="image" src="https://github.com/user-attachments/assets/1747b0b1-97ef-4da0-93bd-0fdf13087dc3" />

After
<img width="1303" height="394" alt="image" src="https://github.com/user-attachments/assets/30a4364e-2930-4a8f-bef9-f36a0708f21e" />
