### PR TITLE
fix: remove ext pan id, pan id and network key from settings due to schema bug

### DIFF
--- a/src/components/settings-page/index.tsx
+++ b/src/components/settings-page/index.tsx
@@ -39,6 +39,7 @@ type SettingsPageState = {
 const ROOT_KEY_NAME = 'main';
 
 const ignoredFields = ['groups', 'devices', 'device_options', 'ban', 'whitelist', 'map_options'];
+const ignoredAdvancedFields = ['ext_pan_id', 'pan_id', 'network_key'];
 const validJsonSchemasAsTabs = ['object', 'array'];
 
 const removePropertiesFromSchema = (
@@ -350,6 +351,11 @@ class SettingsPage extends Component<
             currentConfig = configAndSchema.config[keyName] as Record<string, unknown>;
             if (configAndSchema.schema.properties) {
                 currentSchema = configAndSchema.schema.properties[keyName] as JSONSchema7;
+            }
+            if (keyName === 'advanced') {
+                configAndSchema = removePropertiesFromSchema(ignoredAdvancedFields, currentSchema, currentConfig);
+                currentSchema = configAndSchema.schema;
+                currentConfig = configAndSchema.config;
             }
         }
         return { currentSchema, currentConfig };


### PR DESCRIPTION
These are apparently causing weird issues like https://github.com/Koenkk/zigbee2mqtt/issues/28710
Seems the schema logic is not handling the multi-type well and defaulting or something along those lines.
I'm not able to replicate, must be a specific combo.

Since these settings can be set via onboarding, I figure might as well remove them from frontend since it's dangerous if it starts misbehaving.

@Koenkk I think that extra logic should be enough?